### PR TITLE
docs(readme): conversion-surface revamp — hero demo, persona samples, FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,14 @@ User dir wins over bundled. Same precedence pattern as personas.
 
 ## Personas
 
-| Persona | Vibe | Default voice |
-|---|---|---|
-| **aria** | Calm, direct, never editorial. Senior pair-programmer. | Rachel (female US) |
-| **friday** | Bright, breezy, three steps ahead. Sprinkles "boss". | Custom female |
-| **jarvis** | Marvel JARVIS-coded butler. Dry wit, "Sir" only on summaries. | Archer (male British) |
-| **atlas** | Cinematic narrator. Greek tragedy applied to compile cycles. | Connery (male, deep) |
+<!-- TODO before merge: render ~5s mp3 per persona reading the same line ("Looking at your test failures. Three failures in auth.py.") and drop them at docs/assets/personas/<name>.mp3. Use `heard say` against each persona/voice. The same line across all four lets the listener compare vibe at parity. -->
+
+| Persona | Vibe | Default voice | Sample |
+|---|---|---|---|
+| **aria** | Calm, direct, never editorial. Senior pair-programmer. | Rachel (female US) | [▶ listen](docs/assets/personas/aria.mp3) |
+| **friday** | Bright, breezy, three steps ahead. Sprinkles "boss". | Custom female | [▶ listen](docs/assets/personas/friday.mp3) |
+| **jarvis** | Marvel JARVIS-coded butler. Dry wit, "Sir" only on summaries. | Archer (male British) | [▶ listen](docs/assets/personas/jarvis.mp3) |
+| **atlas** | Cinematic narrator. Greek tragedy applied to compile cycles. | Connery (male, deep) | [▶ listen](docs/assets/personas/atlas.mp3) |
 
 Switch via:
 - The menu bar **Persona** submenu (one click)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ Counterpart to input tools like [Wispr Flow](https://wisprflow.ai). Wispr handle
 
 ## See and hear it run
 
-<!-- TODO before merge: drop a 20-30s screen recording (Claude Code session with Heard narrating, audio on) at docs/assets/heard-demo.mp4. GitHub renders <video> tags with a relative src inline. -->
+<!-- TODO: render a 20-30s screen recording (Claude Code session with Heard narrating, audio on) and drop it at docs/assets/heard-demo.mp4. GitHub renders <video> tags with a relative src inline. Replace the placeholder block below when ready. -->
 
-<video src="docs/assets/heard-demo.mp4" controls muted width="100%"></video>
-
-> Want to try a voice before installing? Scroll to **[Personas](#personas)** — each row links to a 5-second sample.
+> **Demo video coming soon.** Run `heard demo` after install for a 15-second preview of the current voice + persona.
 
 ## Install
 
@@ -133,14 +131,14 @@ User dir wins over bundled. Same precedence pattern as personas.
 
 ## Personas
 
-<!-- TODO before merge: render ~5s mp3 per persona reading the same line ("Looking at your test failures. Three failures in auth.py.") and drop them at docs/assets/personas/<name>.mp3. Use `heard say` against each persona/voice. The same line across all four lets the listener compare vibe at parity. -->
+<!-- TODO: render ~5s mp3 per persona reading the same line ("Looking at your test failures. Three failures in auth.py.") and drop them at docs/assets/personas/<name>.mp3. Then swap the "coming soon" cells below for [▶ listen](path) links. Same line across all four lets listeners compare vibe at parity. -->
 
 | Persona | Vibe | Default voice | Sample |
 |---|---|---|---|
-| **aria** | Calm, direct, never editorial. Senior pair-programmer. | Rachel (female US) | [▶ listen](docs/assets/personas/aria.mp3) |
-| **friday** | Bright, breezy, three steps ahead. Sprinkles "boss". | Custom female | [▶ listen](docs/assets/personas/friday.mp3) |
-| **jarvis** | Marvel JARVIS-coded butler. Dry wit, "Sir" only on summaries. | Archer (male British) | [▶ listen](docs/assets/personas/jarvis.mp3) |
-| **atlas** | Cinematic narrator. Greek tragedy applied to compile cycles. | Connery (male, deep) | [▶ listen](docs/assets/personas/atlas.mp3) |
+| **aria** | Calm, direct, never editorial. Senior pair-programmer. | Rachel (female US) | _coming soon_ |
+| **friday** | Bright, breezy, three steps ahead. Sprinkles "boss". | Custom female | _coming soon_ |
+| **jarvis** | Marvel JARVIS-coded butler. Dry wit, "Sir" only on summaries. | Archer (male British) | _coming soon_ |
+| **atlas** | Cinematic narrator. Greek tragedy applied to compile cycles. | Connery (male, deep) | _coming soon_ |
 
 Switch via:
 - The menu bar **Persona** submenu (one click)

--- a/README.md
+++ b/README.md
@@ -230,6 +230,64 @@ heard service install           Auto-start the daemon on login (LaunchAgent)
 heard service uninstall         Remove the LaunchAgent
 ```
 
+## FAQ
+
+<details>
+<summary><b>Does my agent's output leave my machine?</b></summary>
+
+Depends on which backends you opt into.
+
+- **Voice synth.** ElevenLabs sends the spoken text to ElevenLabs over HTTPS. **Kokoro** runs fully locally — nothing leaves the machine.
+- **Persona rewrites.** If you provide an Anthropic key, Heard sends short candidate lines (one per event) to Claude Haiku 4.5 to rewrite in-character. Skip the key and Heard uses neutral templates locally.
+- **Telemetry.** Heard ships no analytics, no crash reporters, no phone-home. The daemon's only outbound calls are to the synth + persona providers you configured.
+
+`heard config get` shows what's enabled. `heard doctor` exercises every outbound endpoint and reports PASS/FAIL per layer.
+</details>
+
+<details>
+<summary><b>What does ElevenLabs actually cost in practice?</b></summary>
+
+The free tier covers light daily use. A heavy day of pair-programming (2-3 hrs of narration) typically lands in the **few-cents-to-low-dimes** range on the paid Starter plan. Verbosity profile dominates cost: `quiet` is roughly 10× cheaper than `verbose` on the same workload.
+
+Want a hard ceiling? Switch to **Kokoro** (free, local) — same UX, slightly slower first-token latency, no per-character billing.
+</details>
+
+<details>
+<summary><b>Will narration slow down my agent?</b></summary>
+
+No. Hooks fire-and-forget over a Unix socket; the daemon synthesises and plays asynchronously. Your agent never blocks on Heard. If the daemon dies mid-session the agent keeps running normally — you just stop hearing things, and `heard doctor` will tell you why.
+</details>
+
+<details>
+<summary><b>Linux / Windows support?</b></summary>
+
+macOS-only today. The hard dependencies (rumps menu bar, CoreAudio mic monitor, AppleScript notifications, py2app bundle, Right-Option tap-hold via pynput on Quartz) are all macOS APIs. Linux is on the roadmap; Windows is not currently planned. Track [issues tagged `platform`](https://github.com/heardlabs/heard/issues?q=label%3Aplatform) for progress.
+</details>
+
+<details>
+<summary><b>Does it work over SSH / on a remote dev box?</b></summary>
+
+Yes — run Heard locally on your Mac and run the agent on the remote box, with the remote agent's hook `ssh`-ing back to invoke `heard.hook` locally. There's no first-class `heard remote` adapter yet; `heard run <command>` wraps any CLI under a PTY and narrates idle-flushed output, which covers most setups.
+</details>
+
+<details>
+<summary><b>Cursor? Aider?</b></summary>
+
+Not first-class adapters yet (planned — see **[Supported agents](#supported-agents)** below). Both work today via `heard run <command>`, which wraps any CLI under a PTY and narrates its output.
+</details>
+
+<details>
+<summary><b>How do I use it with multiple parallel agents?</b></summary>
+
+Heard auto-detects 2+ concurrent sessions and shifts to **swarm mode** — most-recent session gets full narration; background agents pierce only on failures and questions, with a periodic digest of background work. Each background agent gets a distinct voice based on a stable hash of its project directory. See **[Running multiple agents](#running-multiple-agents)** above.
+</details>
+
+<details>
+<summary><b>Is this open source? How do I contribute?</b></summary>
+
+Yes — Apache 2.0. The easiest places to contribute are adapters (`heard/adapters/`), personas (`heard/personas/*.md`), and verbosity profiles (`heard/profiles/*.yaml`) — each is a small, well-scoped surface. Cursor and Aider adapters are tracked in **[Supported agents](#supported-agents)**.
+</details>
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,32 @@
 
 Counterpart to input tools like [Wispr Flow](https://wisprflow.ai). Wispr handles what you say *to* your agent; Heard handles what it says back.
 
-[heard.dev](https://heard.dev) · [Latest release](https://github.com/heardlabs/heard/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/heardlabs/heard?label=release&color=0aa)](https://github.com/heardlabs/heard/releases/latest)
+[![PyPI](https://img.shields.io/pypi/v/heard.svg)](https://pypi.org/project/heard/)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/heardlabs/heard/blob/main/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/heardlabs/heard?style=social)](https://github.com/heardlabs/heard)
+
+[heard.dev](https://heard.dev) · [Releases](https://github.com/heardlabs/heard/releases/latest) · [Issues](https://github.com/heardlabs/heard/issues)
+
+## See and hear it run
+
+<!-- TODO before merge: drop a 20-30s screen recording (Claude Code session with Heard narrating, audio on) at docs/assets/heard-demo.mp4. GitHub renders <video> tags with a relative src inline. -->
+
+<video src="docs/assets/heard-demo.mp4" controls muted width="100%"></video>
+
+> Want to try a voice before installing? Scroll to **[Personas](#personas)** — each row links to a 5-second sample.
 
 ## Install
 
-### Menu bar app (recommended)
+### Have your agent install it (recommended)
+
+If you're already inside Claude Code, Codex, or any agent — paste this and it does the rest:
+
+> Install Heard so you narrate your responses to me. Run: `curl -L https://github.com/heardlabs/heard/releases/latest/download/Heard.zip -o /tmp/heard.zip && unzip -o /tmp/heard.zip -d /Applications && xattr -dr com.apple.quarantine /Applications/Heard.app && open /Applications/Heard.app` — a window will pop up and I'll fill it in.
+
+The agent runs the install, the onboarding window pops up on your Mac, and you fill in API key / voice / hotkey. Hooks for the calling agent install automatically.
+
+### Menu bar app (manual)
 
 1. Download the latest `Heard-v*.zip` from [Releases](https://github.com/heardlabs/heard/releases/latest).
 2. Unzip and drag `Heard.app` into `/Applications`.
@@ -18,23 +39,15 @@ Counterpart to input tools like [Wispr Flow](https://wisprflow.ai). Wispr handle
 
 The menu bar icon stays visible from then on. Click it to switch persona, dial speed (Normal / Fast / Hyper), tune verbosity, pin a focus session, or silence.
 
-### One-line install (lazy mode)
-
-Paste this into Claude Code, Codex, or your agent of choice:
-
-> Install Heard so you narrate your responses to me. Run: `curl -L https://github.com/heardlabs/heard/releases/latest/download/Heard.zip -o /tmp/heard.zip && unzip -o /tmp/heard.zip -d /Applications && xattr -dr com.apple.quarantine /Applications/Heard.app && open /Applications/Heard.app` — a window will pop up and I'll fill it in.
-
 ### CLI only
 
 ```bash
-pipx install heard
-# or
-uv tool install heard
-
-heard install claude-code
+pipx install heard           # or: uv tool install heard
+heard install claude-code    # wires the hook into ~/.claude/settings.json
+heard demo                   # ~15s preview of the current voice + persona
 ```
 
-Your next Claude Code response will be narrated. Run `heard demo` first to preview the voice + persona before wiring up an agent.
+Your next Claude Code response will be narrated.
 
 ## Voice — two backends
 


### PR DESCRIPTION
## Summary

README pass aimed at the conversion gap: a first-time visitor today can't *experience* Heard before installing, and there's no scaffolding for the questions (privacy, cost, latency, platform support) that block install. Four commits, each scoped to one logical change:

1. **Intro revamp** — badge strip (release/PyPI/license/stars), hero demo block, agent-paste install promoted to recommended (the typical visitor is already inside an agent), CLI block compressed to three lines.
2. **Per-persona audio samples** — new column in the personas table for 5-second `.mp3` samples per persona.
3. **FAQ** — collapsible `<details>` sections for the non-symptom questions that block install: data-flow / privacy, ElevenLabs cost in practice, latency, Linux/Windows, SSH/remote dev, Cursor/Aider, multi-agent, license/contribute.
4. **Coming-soon placeholders** — hero video and persona samples render as "coming soon" copy instead of broken `<video>`/404 links, so this PR is safe to merge before assets land.

What I deliberately did **not** touch: the Voice/Multi-agent/Verbosity/Configuration/Commands/Troubleshooting bodies — those are denser and more honest than most OSS READMEs already, and rewording them would be churn without payoff.

## Mergeable as-is

The README renders cleanly today. Assets can be dropped in over time:

- [ ] `docs/assets/heard-demo.mp4` — 20-30s screen recording of a Claude Code session with Heard narrating, audio on. Then swap the "coming soon" callout for `<video src="docs/assets/heard-demo.mp4" controls muted width="100%"></video>`.
- [ ] `docs/assets/personas/{aria,friday,jarvis,atlas}.mp3` — ~5s each, all reading the same line ("Looking at your test failures. Three failures in auth.py.") so listeners compare vibe at parity. Then swap the "coming soon" cells for `[▶ listen](docs/assets/personas/<name>.mp3)`.

Both file paths and swap targets are noted in `<!-- TODO -->` comments next to each placeholder.