### PR TITLE
Set SSL_CERT_FILE in heard/__init__.py so non-bundle entrypoints get a working CA path

### DIFF
--- a/heard/__init__.py
+++ b/heard/__init__.py
@@ -1,3 +1,28 @@
 """Heard — your AI agent's voice companion."""
 
+from __future__ import annotations
+
+import os
+
 __version__ = "0.1.0"
+
+# The frozen Python inside Heard.app has no system CA path, so any
+# HTTPS call (urllib voice download, anthropic SDK, elevenlabs SDK)
+# fails with CERTIFICATE_VERIFY_FAILED unless SSL_CERT_FILE is pointed
+# at certifi's bundled cacert. `packaging/app_entry.py` already does
+# this for the menu-bar bundle entrypoint, but every other entrypoint
+# bypasses it:
+#   - `python -m heard <cmd>`           (CLI: doctor, demo, say, …)
+#   - `python -m heard.hook <agent>`    (per-event hook subprocess)
+#   - `python -m heard.daemon`          (LaunchAgent / dev runs)
+# Mirror the setup here so importing `heard` from any path is safe.
+# `setdefault` preserves explicit user overrides.
+try:
+    import certifi as _certifi
+
+    _ca = _certifi.where()
+    if _ca:
+        os.environ.setdefault("SSL_CERT_FILE", _ca)
+        os.environ.setdefault("REQUESTS_CA_BUNDLE", _ca)
+except Exception:
+    pass

--- a/tests/test_ssl_cert_env.py
+++ b/tests/test_ssl_cert_env.py
@@ -1,0 +1,47 @@
+"""Heard's package import sets SSL_CERT_FILE / REQUESTS_CA_BUNDLE for
+the bundled .app's frozen Python, where the system CA path is absent.
+The bundle entrypoint (`packaging/app_entry.py`) already does this,
+but `python -m heard <cmd>`, `python -m heard.hook`, and
+`python -m heard.daemon` bypass it — so the same setup also lives in
+the package __init__ as a safety net.
+
+These tests exercise that __init__-level setup directly."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+
+def _reimport_heard() -> None:
+    """Drop heard from sys.modules so the next import re-runs __init__."""
+    for name in list(sys.modules):
+        if name == "heard" or name.startswith("heard."):
+            del sys.modules[name]
+    importlib.import_module("heard")
+
+
+def test_import_sets_ssl_cert_file(monkeypatch):
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+    _reimport_heard()
+
+    ca = os.environ.get("SSL_CERT_FILE")
+    assert ca, "expected SSL_CERT_FILE to be set after `import heard`"
+    assert os.path.exists(ca), f"SSL_CERT_FILE points at non-existent file: {ca}"
+    assert os.environ.get("REQUESTS_CA_BUNDLE") == ca
+
+
+def test_import_does_not_clobber_existing(monkeypatch):
+    sentinel = "/tmp/heard-ssl-sentinel-do-not-create"
+    monkeypatch.setenv("SSL_CERT_FILE", sentinel)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", sentinel)
+
+    _reimport_heard()
+
+    # setdefault must leave a deliberately-set value alone, even if it
+    # points at something that doesn't exist.
+    assert os.environ["SSL_CERT_FILE"] == sentinel
+    assert os.environ["REQUESTS_CA_BUNDLE"] == sentinel


### PR DESCRIPTION
## Summary

`packaging/app_entry.py` points `SSL_CERT_FILE` at `certifi.where()` before any HTTPS-using import — but only for the menu-bar bundle main entry. Every other entrypoint bypasses that file and inherits a frozen Python with no system CA path.

Affected paths:
- `python -m heard <cmd>` — CLI (doctor, demo, say, ...)
- `python -m heard.hook <agent>` — per-event hook subprocess
- `python -m heard.daemon` — LaunchAgent / dev runs

This patch mirrors the certifi setup in `heard/__init__.py`, so importing `heard` from any entrypoint is safe. `setdefault` preserves explicit user overrides.

## Repro

Fresh install on macOS, no `SSL_CERT_FILE` in env, no ElevenLabs key (so Kokoro is the active backend). On first synth attempt:

```
$ /Applications/Heard.app/Contents/MacOS/python -m heard doctor
...
Synth
  · backend               Kokoro (no ElevenLabs key configured)
  ✗ synth                 URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]
                            certificate verify failed: unable to get local issuer
                            certificate (_ssl.c:1032)>
```

Same failure surfaces as the user-facing notification *"Heard — couldn't generate audio. Run `heard doctor` for details."* The daemon's `KokoroTTS.ensure_downloaded()` urlretrieve call fails the same way on first run.

After this patch, the same command resolves the cert path on its own and the synth + download paths work without any wrapper script.

## Tests

`tests/test_ssl_cert_env.py` covers two cases:
1. Importing `heard` with both env vars unset populates `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` to a real on-disk path.
2. Importing `heard` with the vars already set leaves them alone (setdefault semantics).

Local: `ruff check heard/ tests/` clean, `pytest -q` 235 passed.

## Notes

I'm a v0.4 user who hit this on a fresh install today; happy to follow up on related issues (model download truncation with no checksum, persona voice IDs being ElevenLabs-only when Kokoro is the active backend) — filing those as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)