### PR TITLE
ux: terser tool narration + ElevenLabs key onboarding

### DIFF
--- a/heard/assets/key_prompt.html
+++ b/heard/assets/key_prompt.html
@@ -585,20 +585,27 @@
         </div>
       </div>
 
-      <!-- ─────── Screen 2: LLM key (optional) ─────── -->
+      <!-- ─────── Screen 2: API keys (optional) ─────── -->
       <div class="screen" id="screen-2">
-        <h1>Bring your own LLM <span style="opacity:0.5">(optional)</span>.</h1>
+        <h1>Bring your own keys <span style="opacity:0.5">(optional)</span>.</h1>
         <p>
-          Heard rewrites each line through Claude Haiku 4.5 or GPT-4o-mini
-          for richer phrasing. About $1/month at typical use.
-          Skip this and narration falls back to templates — still useful, just stiffer.
+          LLM key powers Haiku/GPT-4o rewrites for richer phrasing.
+          ElevenLabs key swaps the local Kokoro voice for cloud voices.
+          Skip either to keep the defaults.
         </p>
 
         <label class="field">
           <span class="leading">
             <svg viewBox="0 0 16 16" fill="currentColor"><path d="M9 1a4 4 0 0 1 1.3 7.78L11 9l-1 1v1H9v1H8v1H6v-1.5l-.5-.5L5 11v-1l3.31-.37A4 4 0 0 1 9 1zm0 1.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5z"/></svg>
           </span>
-          <input id="llm-key" type="password" placeholder="sk-ant-… or sk-…" autocomplete="off" spellcheck="false" tabindex="0" />
+          <input id="llm-key" type="password" placeholder="LLM key — sk-ant-… or sk-…" autocomplete="off" spellcheck="false" tabindex="0" />
+        </label>
+
+        <label class="field">
+          <span class="leading">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6v4M6 4v8M9 5v6M12 7v2"/></svg>
+          </span>
+          <input id="el-key" type="password" placeholder="ElevenLabs API key" autocomplete="off" spellcheck="false" tabindex="0" />
         </label>
 
         <div class="footer">
@@ -680,7 +687,10 @@
 
 <script>
   var TOTAL_STEPS = 4;
-  var current = 1;
+  // Initial step injected by Python via {{START_STEP}} placeholder. 1 for
+  // first-launch onboarding, 2 for "Set API key…" from the menu (skips
+  // the trial-signup landing).
+  var current = {{START_STEP}};
 
   // Trial state — populated by trialVerify() on success and forwarded
   // to Python in finish(). Empty when user took "Use local voices"
@@ -992,6 +1002,7 @@
 
   function finish() {
     var llm = (document.getElementById('llm-key') || {}).value || '';
+    var elevenlabs = (document.getElementById('el-key') || {}).value || '';
     var agents = [];
     if (document.getElementById('agent-claude-code') && document.getElementById('agent-claude-code').checked) {
       agents.push('claude-code');
@@ -1001,7 +1012,7 @@
     }
     post('finish', {
       llm: llm.trim(),
-      elevenlabs: '',
+      elevenlabs: elevenlabs.trim(),
       agents: agents.join(','),
       heard_token: trial.token,
       heard_plan: trial.plan,
@@ -1054,7 +1065,10 @@
     var input = field.querySelector('input');
     if (input) input.focus();
   });
-  // Screen 1 has no input field, so initial focus on load is a no-op.
+  // Apply the START_STEP injection. setStep handles dot/screen states +
+  // focuses the right input. For start_step=1 (first-launch flow) the
+  // initial active classes already match, so this is a no-op there.
+  if (current !== 1) { setStep(current); }
 </script>
 </body>
 </html>

--- a/heard/client.py
+++ b/heard/client.py
@@ -506,26 +506,33 @@ def handle_cc_pre_tool(data: dict) -> None:
     cfg = config.load()
     session = _session_from_data(data)
 
-    # First, surface any prose Claude wrote leading up to this tool call.
-    # If we said something, the tool announcement would just be noise on
-    # top of it — skip the tool announcement in that case.
+    # Surface any prose Claude wrote leading up to this tool call. We no
+    # longer suppress the tool announcement when prose just spoke — the
+    # tool_pre carries per-file specifics ("Adding the field to the
+    # modal" vs. the prose-level overview), so both narrate.
     transcript = data.get("transcript_path")
-    spoke_text = 0
     if transcript:
-        spoke_text = _speak_unspoken_texts(transcript, session, cfg, finalize=False)
+        _speak_unspoken_texts(transcript, session, cfg, finalize=False)
 
-    if spoke_text > 0:
-        return
     if not cfg.get("narrate_tools", True):
         return
     ev = templates.pre_tool_event(data.get("tool_name") or "", data.get("tool_input") or {})
     if ev is None:
         return
+    # Pull the latest assistant prose into the tool_pre ctx so persona
+    # Haiku can combine the current intent ("…wire up the ElevenLabs
+    # key…") with the specific tool action ("Editing key_window") into
+    # one purposeful status line.
+    ctx = dict(ev.ctx)
+    if transcript:
+        recent = extract_last_assistant_text(transcript)
+        if recent:
+            ctx["recent_intent"] = recent[:400]
     send_event(
         kind="tool_pre",
         neutral=ev.text,
         tag=ev.tag,
-        ctx=ev.ctx,
+        ctx=ctx,
         session=session,
     )
 

--- a/heard/client.py
+++ b/heard/client.py
@@ -506,23 +506,24 @@ def handle_cc_pre_tool(data: dict) -> None:
     cfg = config.load()
     session = _session_from_data(data)
 
-    # Surface any prose Claude wrote leading up to this tool call. We no
-    # longer suppress the tool announcement when prose just spoke — the
-    # tool_pre carries per-file specifics ("Adding the field to the
-    # modal" vs. the prose-level overview), so both narrate.
+    # First, surface any prose Claude wrote leading up to this tool call.
+    # If we said something, the tool announcement would just be noise on
+    # top of it — skip it in that case. When the tool_pre DOES fire (no
+    # fresh prose to suppress), we still enrich its ctx with the latest
+    # transcript prose + the actual change content so persona Haiku can
+    # produce a purposeful status line instead of a bare template verb.
     transcript = data.get("transcript_path")
+    spoke_text = 0
     if transcript:
-        _speak_unspoken_texts(transcript, session, cfg, finalize=False)
+        spoke_text = _speak_unspoken_texts(transcript, session, cfg, finalize=False)
 
+    if spoke_text > 0:
+        return
     if not cfg.get("narrate_tools", True):
         return
     ev = templates.pre_tool_event(data.get("tool_name") or "", data.get("tool_input") or {})
     if ev is None:
         return
-    # Pull the latest assistant prose into the tool_pre ctx so persona
-    # Haiku can combine the current intent ("…wire up the ElevenLabs
-    # key…") with the specific tool action ("Editing key_window") into
-    # one purposeful status line.
     ctx = dict(ev.ctx)
     if transcript:
         recent = extract_last_assistant_text(transcript)

--- a/heard/key_window.py
+++ b/heard/key_window.py
@@ -189,11 +189,19 @@ class _MessageHandler(NSObject):
         self._cb(action, payload_dict)
 
 
-def prompt() -> dict[str, Any]:
+def prompt(start_step: int = 1) -> dict[str, Any]:
     """Show the onboarding flow modally. Returns
     {action, llm, elevenlabs, agents}. action is 'finish' (with
     possibly empty keys if the user skipped) or 'cancel'. agents is
-    a list of agent names the user wants hooks installed for."""
+    a list of agent names the user wants hooks installed for.
+
+    ``start_step`` controls which screen the modal opens on. 1 (default)
+    is the trial-signup landing for first-launch onboarding; 2 is the
+    keys screen, used when the user invoked "Set API key…" from the menu
+    so they don't get bounced through the trial again.
+    """
+    if start_step < 1 or start_step > 4:
+        start_step = 1
     # Cmd-V / Cmd-C / Cmd-A only work if NSApp has a main menu wired
     # to the standard editing selectors. LSUIElement apps don't get one
     # by default; install a hidden minimal Edit menu before the modal
@@ -375,6 +383,9 @@ def prompt() -> dict[str, Any]:
         # Settings before reaching this screen.
         "{{ACCESSIBILITY_GRANTED}}",
         "true" if accessibility.is_trusted() else "false",
+    ).replace(
+        "{{START_STEP}}",
+        str(start_step),
     )
 
     webview.loadHTMLString_baseURL_(html, None)

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -104,16 +104,30 @@ class Persona:
 
         Falls back gracefully: Haiku → template → neutral.
 
-        Haiku only fires for `final` events (the summary at end of a turn).
-        Tool events (tool_pre / tool_post) always use templates — they are
-        short, repetitive, and don't need a model to rewrite, so this keeps
-        per-event TTFA near 300ms instead of ~1.5s.
+        Haiku fires for `final` events and for `tool_pre` events that
+        carry enough ctx (preceding prose intent or actual change
+        content) to do better than the bare template. Templated
+        tool_pre paths without that context still skip Haiku to keep
+        per-event TTFA near 300ms — the rewrite only earns its latency
+        when there's real content to translate.
         """
         if self.is_raw:
             return neutral
 
-        if event_kind == "final" and _haiku_enabled():
-            haiku = _haiku_rewrite(self, event_kind, neutral, tag, ctx or {}, session or {})
+        ctx_for_haiku = ctx or {}
+        haiku_eligible = event_kind == "final"
+        if event_kind == "tool_pre" and (
+            ctx_for_haiku.get("recent_intent")
+            or ctx_for_haiku.get("change_new")
+            or ctx_for_haiku.get("change_old")
+        ):
+            # Enough context for a purposeful rewrite — "Adding the
+            # ElevenLabs field to the modal" beats "Editing key_prompt"
+            # and is worth the Haiku round trip.
+            haiku_eligible = True
+
+        if haiku_eligible and _haiku_enabled():
+            haiku = _haiku_rewrite(self, event_kind, neutral, tag, ctx_for_haiku, session or {})
             if haiku:
                 return haiku
 
@@ -315,10 +329,15 @@ def _build_user_message(
 ) -> str:
     # Recent assistant prose flows in via ctx for tool_pre events so we
     # can produce purposeful status lines ("Adding the field to the
-    # modal") instead of bare templates ("Editing key_window"). Pop it
-    # so it's formatted as its own line, not stuffed into "Context:".
+    # modal") instead of bare templates ("Editing key_window"). The
+    # change snippets (Edit old/new, Write content) flow in similarly so
+    # Haiku can read what's actually being changed and translate to
+    # intent. Pop them so they're formatted as their own labelled lines,
+    # not stuffed into the generic "Context:" key=value bag.
     ctx = dict(ctx) if ctx else {}
     recent_intent = (ctx.pop("recent_intent", "") or "").strip()
+    change_old = (ctx.pop("change_old", "") or "").strip()
+    change_new = (ctx.pop("change_new", "") or "").strip()
 
     lines = [f"Event: {event_kind}", f"Tag: {tag}", f"Neutral narration: {neutral}"]
     if ctx:
@@ -327,6 +346,13 @@ def _build_user_message(
             lines.append(f"Context: {nice}")
     if recent_intent:
         lines.append(f"Current goal (from recent prose): {recent_intent}")
+    if change_old or change_new:
+        # Wrap in delimiters so multi-line code in the snippet doesn't
+        # blur into the surrounding instructions when Haiku reads it.
+        if change_old:
+            lines.append(f"--- Removed by this edit:\n{change_old}\n---")
+        if change_new:
+            lines.append(f"--- Added by this edit:\n{change_new}\n---")
     if session:
         repo = session.get("repo_name")
         fails = session.get("failure_count") or 0
@@ -354,16 +380,19 @@ def _build_user_message(
             "the tool has run. Stay in character. No markdown."
         )
     elif event_kind == "tool_pre" and recent_intent:
-        # When we have intent context, we want a purposeful status line
-        # — not just the template verb + filename. Tell Haiku to lean
-        # on the goal and stay specific to THIS file/action.
+        # Status while a specific tool runs. Phrase, not a sentence —
+        # these fire dozens of times per turn and every word costs
+        # listening time. Default 2-4 words; only stretch to ~7 when
+        # the change genuinely can't be summarised shorter.
         lines.append(
-            "Write ONE brief status sentence I will speak aloud while this "
-            "is happening. PRESENT tense. Combine the current goal with "
-            "this specific tool action — e.g. 'Adding the ElevenLabs field "
-            "to the modal' rather than 'Editing key_prompt'. Mention the "
-            "file by its bare name (no extension). Stay in character. "
-            "No markdown. Do not restate the tag."
+            "Output a PHRASE (not a full sentence). 2-4 words by "
+            "default; extend only if the change is genuinely too "
+            "complex for that. PRESENT-tense gerund verb + object. "
+            "Examples: 'adding ElevenLabs field', 'wiring start_step', "
+            "'dropping extensions'. Reject: full sentences, 'I am…', "
+            "'editing X' (zero info), filenames, articles (a/an/the), "
+            "code tokens, the persona's signature address. No "
+            "punctuation beyond one optional trailing period."
         )
     else:
         # tool_pre without intent, intermediate — work is in flight.

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -313,11 +313,20 @@ def _build_user_message(
     ctx: dict[str, Any],
     session: dict[str, Any],
 ) -> str:
+    # Recent assistant prose flows in via ctx for tool_pre events so we
+    # can produce purposeful status lines ("Adding the field to the
+    # modal") instead of bare templates ("Editing key_window"). Pop it
+    # so it's formatted as its own line, not stuffed into "Context:".
+    ctx = dict(ctx) if ctx else {}
+    recent_intent = (ctx.pop("recent_intent", "") or "").strip()
+
     lines = [f"Event: {event_kind}", f"Tag: {tag}", f"Neutral narration: {neutral}"]
     if ctx:
         nice = ", ".join(f"{k}={v}" for k, v in ctx.items() if v)
         if nice:
             lines.append(f"Context: {nice}")
+    if recent_intent:
+        lines.append(f"Current goal (from recent prose): {recent_intent}")
     if session:
         repo = session.get("repo_name")
         fails = session.get("failure_count") or 0
@@ -344,8 +353,20 @@ def _build_user_message(
             "Write ONE sentence describing what just happened. PAST tense — "
             "the tool has run. Stay in character. No markdown."
         )
+    elif event_kind == "tool_pre" and recent_intent:
+        # When we have intent context, we want a purposeful status line
+        # — not just the template verb + filename. Tell Haiku to lean
+        # on the goal and stay specific to THIS file/action.
+        lines.append(
+            "Write ONE brief status sentence I will speak aloud while this "
+            "is happening. PRESENT tense. Combine the current goal with "
+            "this specific tool action — e.g. 'Adding the ElevenLabs field "
+            "to the modal' rather than 'Editing key_prompt'. Mention the "
+            "file by its bare name (no extension). Stay in character. "
+            "No markdown. Do not restate the tag."
+        )
     else:
-        # tool_pre, intermediate — work is in flight
+        # tool_pre without intent, intermediate — work is in flight.
         lines.append(
             "Write ONE sentence I will speak aloud while this is happening. "
             "PRESENT tense — the work is in progress, not done. Stay in "

--- a/heard/templates.py
+++ b/heard/templates.py
@@ -30,6 +30,17 @@ def _basename(path: str | None) -> str:
     return os.path.basename(path or "")
 
 
+def _spoken_filename(path: str | None) -> str:
+    """Filename for TTS — drops the extension so we don't speak ".py"
+    aloud ("ui dot py"). Bare files like Dockerfile / Makefile keep
+    their full name; dotfiles like .zshrc keep their stem."""
+    name = _basename(path)
+    if not name:
+        return ""
+    stem, ext = os.path.splitext(name)
+    return stem if stem else name
+
+
 _BUILD_VERBS = ("build", "compile", "bundle")
 _TEST_MARKERS = ("pytest", "jest", "vitest", "go test", "cargo test", "rspec", "npm test", "pnpm test", "yarn test")
 _INSTALL_MARKERS = (
@@ -159,15 +170,20 @@ def pre_tool_event(tool_name: str, tool_input: dict[str, Any] | None) -> Narrati
             ctx={"command": (tool_input.get("command") or "").strip()[:200]},
         )
     if tn == "Edit":
-        name = _basename(tool_input.get("file_path"))
-        return Narration(tag="tool_edit", text=f"Editing {name}." if name else "Editing a file.", ctx={"file": name})
+        spoken = _spoken_filename(tool_input.get("file_path"))
+        ctx_name = _basename(tool_input.get("file_path"))
+        text = f"Editing {spoken}." if spoken else "Editing a file."
+        return Narration(tag="tool_edit", text=text, ctx={"file": ctx_name})
     if tn == "Write":
-        name = _basename(tool_input.get("file_path"))
-        return Narration(tag="tool_write", text=f"Writing {name}." if name else "Writing a file.", ctx={"file": name})
+        spoken = _spoken_filename(tool_input.get("file_path"))
+        ctx_name = _basename(tool_input.get("file_path"))
+        text = f"Writing {spoken}." if spoken else "Writing a file."
+        return Narration(tag="tool_write", text=text, ctx={"file": ctx_name})
     if tn == "NotebookEdit":
-        name = _basename(tool_input.get("notebook_path"))
-        text = f"Editing {name}." if name else "Editing a notebook."
-        return Narration(tag="tool_edit", text=text, ctx={"file": name})
+        spoken = _spoken_filename(tool_input.get("notebook_path"))
+        ctx_name = _basename(tool_input.get("notebook_path"))
+        text = f"Editing {spoken}." if spoken else "Editing a notebook."
+        return Narration(tag="tool_edit", text=text, ctx={"file": ctx_name})
     if tn == "Read":
         return None
     if tn == "Glob":

--- a/heard/templates.py
+++ b/heard/templates.py
@@ -26,6 +26,14 @@ class Narration:
     ctx: dict[str, Any] = field(default_factory=dict)
 
 
+# Per-side cap for change snippets passed into tool_pre ctx (Edit
+# old/new, Write content, NotebookEdit new_source). Persona Haiku
+# reads them as raw context, not for narration. 400 chars is enough
+# for Haiku to identify a feature add / refactor / config tweak
+# without bloating the prompt for very large rewrites.
+_CHANGE_SNIPPET_CAP = 400
+
+
 def _basename(path: str | None) -> str:
     return os.path.basename(path or "")
 
@@ -173,17 +181,39 @@ def pre_tool_event(tool_name: str, tool_input: dict[str, Any] | None) -> Narrati
         spoken = _spoken_filename(tool_input.get("file_path"))
         ctx_name = _basename(tool_input.get("file_path"))
         text = f"Editing {spoken}." if spoken else "Editing a file."
-        return Narration(tag="tool_edit", text=text, ctx={"file": ctx_name})
+        return Narration(
+            tag="tool_edit",
+            text=text,
+            ctx={
+                "file": ctx_name,
+                "change_old": (tool_input.get("old_string") or "")[:_CHANGE_SNIPPET_CAP],
+                "change_new": (tool_input.get("new_string") or "")[:_CHANGE_SNIPPET_CAP],
+            },
+        )
     if tn == "Write":
         spoken = _spoken_filename(tool_input.get("file_path"))
         ctx_name = _basename(tool_input.get("file_path"))
         text = f"Writing {spoken}." if spoken else "Writing a file."
-        return Narration(tag="tool_write", text=text, ctx={"file": ctx_name})
+        return Narration(
+            tag="tool_write",
+            text=text,
+            ctx={
+                "file": ctx_name,
+                "change_new": (tool_input.get("content") or "")[:_CHANGE_SNIPPET_CAP],
+            },
+        )
     if tn == "NotebookEdit":
         spoken = _spoken_filename(tool_input.get("notebook_path"))
         ctx_name = _basename(tool_input.get("notebook_path"))
         text = f"Editing {spoken}." if spoken else "Editing a notebook."
-        return Narration(tag="tool_edit", text=text, ctx={"file": ctx_name})
+        return Narration(
+            tag="tool_edit",
+            text=text,
+            ctx={
+                "file": ctx_name,
+                "change_new": (tool_input.get("new_source") or "")[:_CHANGE_SNIPPET_CAP],
+            },
+        )
     if tn == "Read":
         return None
     if tn == "Glob":

--- a/heard/ui.py
+++ b/heard/ui.py
@@ -578,25 +578,31 @@ class HeardApp(rumps.App):
             pass
 
     def on_set_api_keys(self, _sender) -> None:
-        self._prompt_api_key()
+        # Land on Screen 2 (keys) so menu users skip the trial-signup
+        # landing — they're explicitly here to enter a key, not sign in.
+        self._prompt_api_key(start_step=2)
         try:
             client.send({"cmd": "reload"})
         except Exception:
             pass
         self.refresh(None)
 
-    def _prompt_api_key(self) -> None:
+    def _prompt_api_key(self, start_step: int = 1) -> None:
         """Four-step onboarding window. Saves whichever keys the user
         provides into config, installs hooks for the agents they
         selected, and marks the user as onboarded so we never re-show
-        this on subsequent launches."""
+        this on subsequent launches.
+
+        ``start_step`` selects which screen the modal opens on (1 = trial
+        signup, 2 = keys). Defaults to 1 for first-launch onboarding.
+        """
         try:
             from heard import key_window
         except Exception as e:
             print(f"key_window unavailable: {e}", file=sys.stderr)
             return
 
-        result = key_window.prompt()
+        result = key_window.prompt(start_step=start_step)
         # Always mark onboarded once they've seen the flow — even if they
         # clicked Skip — so we don't re-prompt on every launch.
         config.set_value("onboarded", True)

--- a/tests/test_intermediate_text.py
+++ b/tests/test_intermediate_text.py
@@ -66,7 +66,7 @@ def test_filter_unspoken_skips_already_marked():
     assert out == ["Second prose."]
 
 
-def test_pre_tool_speaks_intermediate_then_skips_tool_announcement(
+def test_pre_tool_speaks_intermediate_then_announces_tool_with_intent(
     tmp_path, monkeypatch
 ):
     transcript = tmp_path / "t.jsonl"
@@ -95,10 +95,15 @@ def test_pre_tool_speaks_intermediate_then_skips_tool_announcement(
         }
     )
 
-    # We expect ONE event: the prose, NOT a tool announcement.
-    assert len(sent) == 1
+    # Both fire: prose narrates the overall intent, tool_pre carries the
+    # specific action with recent_intent in ctx so persona Haiku can
+    # combine them into a purposeful per-tool status line.
+    assert len(sent) == 2
     assert sent[0]["kind"] == "intermediate"
     assert "Doing what I can automatically" in sent[0]["neutral"]
+    assert sent[1]["kind"] == "tool_pre"
+    assert sent[1]["ctx"].get("recent_intent")
+    assert "Doing what I can automatically" in sent[1]["ctx"]["recent_intent"]
 
 
 def test_pre_tool_announces_tool_when_no_preceding_prose(tmp_path, monkeypatch):

--- a/tests/test_intermediate_text.py
+++ b/tests/test_intermediate_text.py
@@ -66,7 +66,7 @@ def test_filter_unspoken_skips_already_marked():
     assert out == ["Second prose."]
 
 
-def test_pre_tool_speaks_intermediate_then_announces_tool_with_intent(
+def test_pre_tool_speaks_intermediate_then_skips_tool_announcement(
     tmp_path, monkeypatch
 ):
     transcript = tmp_path / "t.jsonl"
@@ -95,15 +95,57 @@ def test_pre_tool_speaks_intermediate_then_announces_tool_with_intent(
         }
     )
 
-    # Both fire: prose narrates the overall intent, tool_pre carries the
-    # specific action with recent_intent in ctx so persona Haiku can
-    # combine them into a purposeful per-tool status line.
-    assert len(sent) == 2
+    # We expect ONE event: the prose, NOT a tool announcement. The
+    # prose IS the intent; doubling it with "Running ps." would be
+    # noise.
+    assert len(sent) == 1
     assert sent[0]["kind"] == "intermediate"
     assert "Doing what I can automatically" in sent[0]["neutral"]
-    assert sent[1]["kind"] == "tool_pre"
-    assert sent[1]["ctx"].get("recent_intent")
-    assert "Doing what I can automatically" in sent[1]["ctx"]["recent_intent"]
+
+
+def test_pre_tool_carries_recent_intent_when_prior_prose_already_spoken(
+    tmp_path, monkeypatch
+):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            ("user", [{"type": "text", "text": "go"}]),
+            ("assistant", [{"type": "text", "text": "Wiring up the ElevenLabs key."}]),
+            ("assistant", [{"type": "tool_use", "name": "Edit"}]),
+        ],
+    )
+    sent: list[dict] = []
+    monkeypatch.setattr(client, "send_event", lambda **kw: sent.append(kw))
+
+    # Pretend the prose was spoken in an earlier hook so it doesn't
+    # fire fresh in this call — tool_pre will reach the send path.
+    spoken.mark_spoken("session-recent", "Wiring up the ElevenLabs key.")
+
+    client.handle_cc_pre_tool(
+        {
+            "session_id": "session-recent",
+            "transcript_path": str(transcript),
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": "/repo/heard/key_window.py",
+                "old_string": "def prompt():",
+                "new_string": "def prompt(start_step: int = 1):",
+            },
+        }
+    )
+
+    # Tool_pre fires (no fresh prose to suppress) with the prior
+    # prose riding along as recent_intent so Haiku has the goal,
+    # plus the change snippets so it can see what's actually
+    # different. This is what enables "Wiring up the ElevenLabs
+    # key entry in key_window" instead of bare "Editing key_window".
+    assert len(sent) == 1
+    assert sent[0]["kind"] == "tool_pre"
+    ctx = sent[0]["ctx"]
+    assert "Wiring up the ElevenLabs key" in ctx.get("recent_intent", "")
+    assert ctx.get("change_old") == "def prompt():"
+    assert ctx.get("change_new") == "def prompt(start_step: int = 1):"
 
 
 def test_pre_tool_announces_tool_when_no_preceding_prose(tmp_path, monkeypatch):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -17,9 +17,23 @@ def test_bash_generic_uses_description():
     assert line == "Do the thing."
 
 
-def test_edit_uses_basename():
+def test_edit_uses_basename_without_extension():
+    # Extension is dropped so TTS doesn't read ".py" as "dot py".
     line = templates.pre_tool_line("Edit", {"file_path": "/Users/x/project/auth.py"})
-    assert line == "Editing auth.py."
+    assert line == "Editing auth."
+
+
+def test_edit_keeps_dotfile_stem():
+    # Dotfiles like .zshrc have empty stem on splitext; we keep the
+    # dotted name rather than narrating an empty filename.
+    line = templates.pre_tool_line("Edit", {"file_path": "/Users/x/.zshrc"})
+    assert line == "Editing .zshrc."
+
+
+def test_edit_keeps_extensionless_name():
+    # Dockerfile, Makefile, etc. — no extension to strip.
+    line = templates.pre_tool_line("Edit", {"file_path": "/repo/Dockerfile"})
+    assert line == "Editing Dockerfile."
 
 
 def test_read_is_silent():


### PR DESCRIPTION
## Summary

- **Onboarding**: adds an ElevenLabs key field to the modal's keys screen and routes the menubar's "Set API key…" past the trial-signup landing.
- **Narration**: file-edit announcements now describe intent ("adding ElevenLabs field") instead of bare templates ("editing key_prompt"). Haiku gets the recent prose plus the actual change snippets and outputs a 2-4 word phrase.
- **Filenames**: spoken without extensions so TTS doesn't read ".py" as "dot py".

If a prose block just narrated, the tool announcement still suppresses (no doubling up). Tests cover the suppression, the prior-prose-already-spoken path, and extension stripping for common file shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)