### PR TITLE
fix(onboarding + narration): Skip advances steps; tool_pre includes filename

### DIFF
--- a/heard/assets/key_prompt.html
+++ b/heard/assets/key_prompt.html
@@ -448,7 +448,7 @@
           </span>
           <span>heard</span>
         </div>
-        <button class="skip-top" onclick="finish()">Skip</button>
+        <button class="skip-top" onclick="skipStep()">Skip</button>
       </div>
 
       <div class="screens-area">
@@ -724,6 +724,16 @@
     }
   }
   function goto(n) { setStep(n); }
+
+  // Top-of-modal Skip button. Advances to the next step rather than
+  // closing the whole flow — most users want to skip *this* step
+  // (trial signup, key entry, etc.) and continue, not bail entirely.
+  // On the final step there's nowhere to advance to, so we defer to
+  // finish() which submits whatever's been entered so far.
+  function skipStep() {
+    if (current < TOTAL_STEPS) goto(current + 1);
+    else finish();
+  }
   function post(action, payload) {
     try {
       window.webkit.messageHandlers.heard.postMessage({ action: action, payload: payload || {} });

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -389,16 +389,18 @@ def _build_user_message(
         is_file_change = bool(file_name) and tag in ("tool_edit", "tool_write")
         if is_file_change:
             lines.append(
-                "Output the form: '<gerund verb> <file>, <intent phrase>'. "
-                "PRESENT tense. Drop the file extension. The verb names "
-                "the operation (editing, writing, refactoring, scaffolding, "
-                "etc). The intent phrase is 2-4 words describing what "
-                "THIS specific change does. Examples: 'editing key_window, "
-                "wiring start_step', 'editing templates, dropping "
-                "extensions', 'writing key_prompt, scaffolding modal'. "
-                "Reject: full sentences, articles (a/an/the), code tokens, "
-                "the persona's signature address. One optional trailing "
-                "period; no other punctuation beyond the comma."
+                "Output the form: '<intent phrase> in <file>'. The "
+                "filename is REQUIRED — an output that omits it is "
+                "invalid; emit it again with the file. PRESENT tense, "
+                "4-7 words total. Drop the file extension when speaking "
+                "the name. The intent phrase is 2-4 words on what THIS "
+                "specific change does. Examples: 'fixing skip step in "
+                "key_prompt', 'wiring start_step in key_window', "
+                "'dropping extensions in templates', 'adding ElevenLabs "
+                "field in key_prompt'. Reject: full sentences, articles "
+                "(a/an/the), code tokens, the persona's signature "
+                "address, outputs without a file. One optional trailing "
+                "period; no other punctuation."
             )
         else:
             lines.append(


### PR DESCRIPTION
## Summary

Two small UX fixes.

The top-right Skip button on the onboarding modal called \`finish()\` and closed the whole flow. New \`skipStep()\` helper advances to the next screen on 1-3 and falls back to \`finish()\` on the final screen.

The persona tool_pre prompt let Haiku drop the filename, so users heard things like "fixing a skip button" with no file grounding it. Switch the form to "<intent phrase> in <file>" with explicit "filename is REQUIRED" — outputs that omit the file are invalid. Examples now read like "fixing skip step in key_prompt".

🤖 Generated with [Claude Code](https://claude.com/claude-code)