### PR TITLE
feat(narration): fall back to claude -p when no Anthropic key

### DIFF
--- a/heard/hook.py
+++ b/heard/hook.py
@@ -7,6 +7,7 @@ Reads the hook payload from stdin, routes by hook_event_name.
 from __future__ import annotations
 
 import json
+import os
 import sys
 
 from heard import client
@@ -49,6 +50,14 @@ AGENTS = {
 
 
 def main() -> None:
+    # The narration pipeline's CLI fallback shells out to `claude -p`
+    # for rewrites when no Anthropic API key is set. That subprocess
+    # would otherwise re-enter this hook on its Stop event and chase
+    # its own tail — daemon narrates → spawns claude → claude finishes
+    # → Stop hook → daemon narrates → … Bail out cleanly so the
+    # in-flight subprocess never feeds the daemon.
+    if os.environ.get("HEARD_HOOK_DISABLED") == "1":
+        sys.exit(0)
     if len(sys.argv) < 2:
         sys.exit(0)
     fn = AGENTS.get(sys.argv[1])

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -309,10 +309,23 @@ def _managed_rewrite_available() -> bool:
     return True
 
 
+def _cli_rewrite_available() -> bool:
+    """True if `claude` is on disk — the last-ditch fallback before
+    templates. The user almost certainly has it installed, because
+    Heard hooks ride on Claude Code's hook system."""
+    from heard import providers
+
+    return providers._find_claude_binary() is not None
+
+
 def _haiku_enabled() -> bool:
-    """True if either signal is available: BYOK Anthropic key, or
-    Heard cloud LLM via an active plan."""
-    return bool(_anthropic_key()) or _managed_rewrite_available()
+    """True if any of the three rewrite signals is available: BYOK
+    Anthropic key, Heard cloud LLM via an active plan, or `claude -p`."""
+    return (
+        bool(_anthropic_key())
+        or _managed_rewrite_available()
+        or _cli_rewrite_available()
+    )
 
 
 _client = None
@@ -345,16 +358,17 @@ def _haiku_rewrite(
     ctx: dict[str, Any],
     session: dict[str, Any],
 ) -> str | None:
-    """Dispatch a Haiku rewrite. Prefers the user's BYOK Anthropic key
-    (they pay their own bill, no Heard cap) — so "I capped out, here's
-    my key" just works: set anthropic_api_key and the next event uses
-    it. Falls back to Heard's cloud /v1/persona-rewrite proxy when on a
-    trial/pro plan and not capped for the day; returns None when neither
-    is available, so callers fall through to template-only narration."""
+    """Dispatch a Haiku rewrite. Ladder: BYOK Anthropic key (the user
+    pays their own bill, no Heard cap) → Heard cloud /v1/persona-rewrite
+    proxy (active plan, not capped today) → `claude -p` (OAuth from the
+    user's keychain — works as long as Claude Code is installed) →
+    None, so callers fall through to template-only narration."""
     if _anthropic_key():
         return _byok_haiku_rewrite(persona, event_kind, neutral, tag, ctx, session)
     if _managed_rewrite_available() and not _managed_haiku_capped_today():
         return _managed_haiku_rewrite(persona, event_kind, neutral, tag, ctx, session)
+    if _cli_rewrite_available():
+        return _cli_haiku_rewrite(persona, event_kind, neutral, tag, ctx, session)
     return None
 
 
@@ -543,6 +557,32 @@ def _managed_haiku_rewrite(
         return None
     except (_urlerr.URLError, TimeoutError, OSError, ValueError):
         return None
+
+
+def _cli_haiku_rewrite(
+    persona: Persona,
+    event_kind: str,
+    neutral: str,
+    tag: str,
+    ctx: dict[str, Any],
+    session: dict[str, Any],
+) -> str | None:
+    """`claude -p` fallback. Used when there's no BYOK key and no Heard
+    cloud plan, but `claude` is installed locally — which is the common
+    case, since Heard's hooks ride on Claude Code."""
+    from heard import providers
+
+    binary = providers._find_claude_binary()
+    if not binary:
+        return None
+    user_msg = _build_user_message(event_kind, neutral, tag, ctx, session)
+    full_system = _SHARED_NARRATION_RULES + "\n\n" + persona.system_prompt
+    return providers.ClaudeCLIProvider(binary=binary).rewrite(
+        system=full_system,
+        user=user_msg,
+        max_tokens=HAIKU_MAX_TOKENS,
+        timeout=HAIKU_TIMEOUT_S,
+    )
 
 
 def _build_user_message(

--- a/heard/providers.py
+++ b/heard/providers.py
@@ -1,31 +1,7 @@
 """Narration LLM providers.
 
-Heard rewrites event lines through a small LLM (Haiku) before TTS. The
-default path is the Anthropic API with ``ANTHROPIC_API_KEY``. When that
-key isn't available, we fall back to the ``claude`` CLI in print mode
-(``claude -p``) — the user almost certainly has Claude Code installed
-because that's how Heard hooks in to begin with, and Claude Code carries
-its own OAuth auth from the keychain.
-
-Why a provider abstraction at all: the call site in ``persona.py`` only
-needs ``rewrite(system, user) -> str | None``. Whether that's an HTTPS
-request or a subprocess is irrelevant to it.
-
-Safety knobs on the CLI fallback:
-  - ``--tools ""``       no tool calls → no PreToolUse / PostToolUse
-                         hooks fire → no recursion into Heard's own
-                         hook.
-  - ``--setting-sources project``  skip ``~/.claude/settings.json``
-                         where Heard's Stop hook lives. Belt-and-
-                         suspenders with the env var below.
-  - ``HEARD_HOOK_DISABLED=1`` in child env. If the Stop hook somehow
-                         still fires, ``heard.hook.main`` short-circuits.
-  - ``--no-session-persistence``  don't litter the user's session list
-                         with narration rewrites.
-  - ``--disable-slash-commands``  no skills resolving from our prompt.
-  - hard subprocess timeout. The narration pipeline already tolerates
-    ``None`` (falls back to templates) so a slow CLI just means the
-    user hears the template line, not a hang.
+Picks the Anthropic API when a key is set, falls back to `claude -p`
+otherwise. The persona layer treats `None` as "use templates".
 """
 
 from __future__ import annotations
@@ -33,18 +9,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import tempfile
 from typing import Protocol
 
-# Same dated model id as persona.py uses for the direct-API path —
-# keep them in lockstep so narration tone stays identical across the
-# two routes.
 HAIKU_MODEL = "claude-haiku-4-5-20251001"
 
-# Locations to look for the `claude` binary when the daemon's PATH is
-# sanitized (which happens when Heard.app launches from LaunchServices /
-# the menu bar — PATH is roughly /usr/bin:/bin:/usr/sbin:/sbin). Order
-# matters: prefer the npm-global install most users have, then the
-# common Homebrew prefixes.
+# Heard.app launches with a sanitized PATH; cover the npm-global and
+# Homebrew prefixes where `claude` usually lives.
 _CLAUDE_PATH_FALLBACKS = (
     os.path.expanduser("~/.npm-global/bin/claude"),
     "/opt/homebrew/bin/claude",
@@ -64,9 +35,6 @@ class NarrationProvider(Protocol):
 
 
 class AnthropicAPIProvider:
-    """Direct Anthropic Messages API. Fast and cheap; only available
-    when an API key is configured."""
-
     name = "anthropic-api"
 
     def __init__(self, api_key: str) -> None:
@@ -105,12 +73,9 @@ class AnthropicAPIProvider:
 
 
 class ClaudeCLIProvider:
-    """Shells out to `claude -p`. Used as a fallback when no API key is
-    set — the user is presumed to have Claude Code installed and
-    OAuth-logged-in via the keychain, since that's how Heard hooks
-    into Claude Code in the first place."""
-
     name = "claude-cli"
+    # Node startup + auth verification overruns the 2.5s HTTPS budget.
+    MIN_TIMEOUT_S = 8.0
 
     def __init__(self, binary: str) -> None:
         self._binary = binary
@@ -119,64 +84,48 @@ class ClaudeCLIProvider:
         return [
             self._binary,
             "-p",
-            "--model",
-            HAIKU_MODEL,
-            "--tools",
-            "",
+            "--model", HAIKU_MODEL,
+            # No tool calls → no Pre/PostToolUse hooks → no recursion.
+            "--tools", "",
             "--disable-slash-commands",
             "--no-session-persistence",
-            "--setting-sources",
-            "project",
-            "--output-format",
-            "text",
-            "--system-prompt",
-            system,
+            # Skip ~/.claude/settings.json (where Heard's Stop hook is).
+            "--setting-sources", "project",
+            "--output-format", "text",
+            "--system-prompt", system,
             user,
         ]
 
     def _build_env(self) -> dict[str, str]:
         env = dict(os.environ)
-        # Belt-and-suspenders: even if --setting-sources project doesn't
-        # fully suppress Heard's Stop hook for some claude version, the
-        # hook itself short-circuits on this flag.
+        # Latch in case Stop hook still fires; heard.hook.main checks this.
         env["HEARD_HOOK_DISABLED"] = "1"
-        # If ANTHROPIC_API_KEY is empty-string in env (set but blank),
-        # claude treats it as present and may error. Drop it so the
-        # OAuth/keychain path is used cleanly.
+        # Blank-string key makes claude pick the wrong auth path.
         if not env.get("ANTHROPIC_API_KEY", "").strip():
             env.pop("ANTHROPIC_API_KEY", None)
         return env
 
-    # Floor for subprocess timeout. The HTTPS path tolerates ~2.5s
-    # comfortably; `claude -p` adds Node startup + auth verification,
-    # so anything under ~8s times out every call. The persona layer
-    # treats a `None` return as "use the template" — this is purely
-    # an upper bound on how long we wait before giving up.
-    MIN_TIMEOUT_S = 8.0
-
     def rewrite(
         self, system: str, user: str, max_tokens: int, timeout: float
     ) -> str | None:
-        # max_tokens isn't directly exposed by `claude -p` — the model
-        # decides. We accept it for API-shape symmetry; the system prompt
-        # already constrains length to a sentence or two for narration.
-        del max_tokens
-        effective_timeout = max(timeout, self.MIN_TIMEOUT_S)
+        del max_tokens  # claude -p doesn't expose it; system prompt caps length.
         try:
             res = subprocess.run(
                 self._build_argv(system, user),
                 env=self._build_env(),
+                # Run from tempdir so claude can't pick up CLAUDE.md or
+                # project-local .claude/ from whatever cwd the daemon is in.
+                cwd=tempfile.gettempdir(),
                 stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
-                timeout=effective_timeout,
+                timeout=max(timeout, self.MIN_TIMEOUT_S),
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             return None
         if res.returncode != 0:
             return None
-        out = (res.stdout or "").strip()
-        return out or None
+        return (res.stdout or "").strip() or None
 
 
 def _find_claude_binary() -> str | None:
@@ -190,13 +139,8 @@ def _find_claude_binary() -> str | None:
 
 
 def get_provider(api_key: str = "") -> NarrationProvider | None:
-    """Pick a provider. API key wins if present; otherwise try the
-    `claude` CLI. Returns ``None`` if neither is available — the
-    persona layer interprets that as "use templates"."""
-    key = (api_key or "").strip()
-    if key:
-        return AnthropicAPIProvider(api_key=key)
+    """API if a key is set, else CLI if `claude` is on disk, else None."""
+    if (api_key or "").strip():
+        return AnthropicAPIProvider(api_key=api_key.strip())
     binary = _find_claude_binary()
-    if binary:
-        return ClaudeCLIProvider(binary=binary)
-    return None
+    return ClaudeCLIProvider(binary=binary) if binary else None

--- a/heard/providers.py
+++ b/heard/providers.py
@@ -1,0 +1,202 @@
+"""Narration LLM providers.
+
+Heard rewrites event lines through a small LLM (Haiku) before TTS. The
+default path is the Anthropic API with ``ANTHROPIC_API_KEY``. When that
+key isn't available, we fall back to the ``claude`` CLI in print mode
+(``claude -p``) — the user almost certainly has Claude Code installed
+because that's how Heard hooks in to begin with, and Claude Code carries
+its own OAuth auth from the keychain.
+
+Why a provider abstraction at all: the call site in ``persona.py`` only
+needs ``rewrite(system, user) -> str | None``. Whether that's an HTTPS
+request or a subprocess is irrelevant to it.
+
+Safety knobs on the CLI fallback:
+  - ``--tools ""``       no tool calls → no PreToolUse / PostToolUse
+                         hooks fire → no recursion into Heard's own
+                         hook.
+  - ``--setting-sources project``  skip ``~/.claude/settings.json``
+                         where Heard's Stop hook lives. Belt-and-
+                         suspenders with the env var below.
+  - ``HEARD_HOOK_DISABLED=1`` in child env. If the Stop hook somehow
+                         still fires, ``heard.hook.main`` short-circuits.
+  - ``--no-session-persistence``  don't litter the user's session list
+                         with narration rewrites.
+  - ``--disable-slash-commands``  no skills resolving from our prompt.
+  - hard subprocess timeout. The narration pipeline already tolerates
+    ``None`` (falls back to templates) so a slow CLI just means the
+    user hears the template line, not a hang.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import Protocol
+
+# Same dated model id as persona.py uses for the direct-API path —
+# keep them in lockstep so narration tone stays identical across the
+# two routes.
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+
+# Locations to look for the `claude` binary when the daemon's PATH is
+# sanitized (which happens when Heard.app launches from LaunchServices /
+# the menu bar — PATH is roughly /usr/bin:/bin:/usr/sbin:/sbin). Order
+# matters: prefer the npm-global install most users have, then the
+# common Homebrew prefixes.
+_CLAUDE_PATH_FALLBACKS = (
+    os.path.expanduser("~/.npm-global/bin/claude"),
+    "/opt/homebrew/bin/claude",
+    "/usr/local/bin/claude",
+    os.path.expanduser("~/.volta/bin/claude"),
+    os.path.expanduser("~/.local/bin/claude"),
+)
+
+
+class NarrationProvider(Protocol):
+    name: str
+
+    def rewrite(
+        self, system: str, user: str, max_tokens: int, timeout: float
+    ) -> str | None:
+        ...
+
+
+class AnthropicAPIProvider:
+    """Direct Anthropic Messages API. Fast and cheap; only available
+    when an API key is configured."""
+
+    name = "anthropic-api"
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                from anthropic import Anthropic
+
+                self._client = Anthropic(api_key=self._api_key)
+            except Exception:
+                self._client = False
+        return self._client or None
+
+    def rewrite(
+        self, system: str, user: str, max_tokens: int, timeout: float
+    ) -> str | None:
+        client = self._get_client()
+        if client is None:
+            return None
+        try:
+            msg = client.messages.create(
+                model=HAIKU_MODEL,
+                max_tokens=max_tokens,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+                timeout=timeout,
+            )
+            parts = [b.text for b in msg.content if getattr(b, "type", "") == "text"]
+            out = " ".join(p.strip() for p in parts if p).strip()
+            return out or None
+        except Exception:
+            return None
+
+
+class ClaudeCLIProvider:
+    """Shells out to `claude -p`. Used as a fallback when no API key is
+    set — the user is presumed to have Claude Code installed and
+    OAuth-logged-in via the keychain, since that's how Heard hooks
+    into Claude Code in the first place."""
+
+    name = "claude-cli"
+
+    def __init__(self, binary: str) -> None:
+        self._binary = binary
+
+    def _build_argv(self, system: str, user: str) -> list[str]:
+        return [
+            self._binary,
+            "-p",
+            "--model",
+            HAIKU_MODEL,
+            "--tools",
+            "",
+            "--disable-slash-commands",
+            "--no-session-persistence",
+            "--setting-sources",
+            "project",
+            "--output-format",
+            "text",
+            "--system-prompt",
+            system,
+            user,
+        ]
+
+    def _build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        # Belt-and-suspenders: even if --setting-sources project doesn't
+        # fully suppress Heard's Stop hook for some claude version, the
+        # hook itself short-circuits on this flag.
+        env["HEARD_HOOK_DISABLED"] = "1"
+        # If ANTHROPIC_API_KEY is empty-string in env (set but blank),
+        # claude treats it as present and may error. Drop it so the
+        # OAuth/keychain path is used cleanly.
+        if not env.get("ANTHROPIC_API_KEY", "").strip():
+            env.pop("ANTHROPIC_API_KEY", None)
+        return env
+
+    # Floor for subprocess timeout. The HTTPS path tolerates ~2.5s
+    # comfortably; `claude -p` adds Node startup + auth verification,
+    # so anything under ~8s times out every call. The persona layer
+    # treats a `None` return as "use the template" — this is purely
+    # an upper bound on how long we wait before giving up.
+    MIN_TIMEOUT_S = 8.0
+
+    def rewrite(
+        self, system: str, user: str, max_tokens: int, timeout: float
+    ) -> str | None:
+        # max_tokens isn't directly exposed by `claude -p` — the model
+        # decides. We accept it for API-shape symmetry; the system prompt
+        # already constrains length to a sentence or two for narration.
+        del max_tokens
+        effective_timeout = max(timeout, self.MIN_TIMEOUT_S)
+        try:
+            res = subprocess.run(
+                self._build_argv(system, user),
+                env=self._build_env(),
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return None
+        if res.returncode != 0:
+            return None
+        out = (res.stdout or "").strip()
+        return out or None
+
+
+def _find_claude_binary() -> str | None:
+    p = shutil.which("claude")
+    if p:
+        return p
+    for cand in _CLAUDE_PATH_FALLBACKS:
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+    return None
+
+
+def get_provider(api_key: str = "") -> NarrationProvider | None:
+    """Pick a provider. API key wins if present; otherwise try the
+    `claude` CLI. Returns ``None`` if neither is available — the
+    persona layer interprets that as "use templates"."""
+    key = (api_key or "").strip()
+    if key:
+        return AnthropicAPIProvider(api_key=key)
+    binary = _find_claude_binary()
+    if binary:
+        return ClaudeCLIProvider(binary=binary)
+    return None

--- a/tests/test_hook_disabled.py
+++ b/tests/test_hook_disabled.py
@@ -1,0 +1,43 @@
+"""Hook short-circuit when HEARD_HOOK_DISABLED is set.
+
+This is the safety latch for the CLI narration fallback: when the
+daemon spawns `claude -p` to do a rewrite, the spawned subprocess
+fires a Stop hook back into Heard. Without this latch we'd recurse.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from heard import hook
+
+
+def test_main_exits_early_when_disabled(monkeypatch):
+    monkeypatch.setenv("HEARD_HOOK_DISABLED", "1")
+    monkeypatch.setattr(sys, "argv", ["heard.hook", "claude-code"])
+
+    calls = {"n": 0}
+
+    def fake_cc():
+        calls["n"] += 1
+
+    monkeypatch.setitem(hook.AGENTS, "claude-code", fake_cc)
+    try:
+        hook.main()
+    except SystemExit as e:
+        assert e.code == 0
+    assert calls["n"] == 0
+
+
+def test_main_dispatches_when_not_disabled(monkeypatch):
+    monkeypatch.delenv("HEARD_HOOK_DISABLED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["heard.hook", "claude-code"])
+
+    calls = {"n": 0}
+
+    def fake_cc():
+        calls["n"] += 1
+
+    monkeypatch.setitem(hook.AGENTS, "claude-code", fake_cc)
+    hook.main()
+    assert calls["n"] == 1

--- a/tests/test_hook_disabled.py
+++ b/tests/test_hook_disabled.py
@@ -1,9 +1,5 @@
-"""Hook short-circuit when HEARD_HOOK_DISABLED is set.
-
-This is the safety latch for the CLI narration fallback: when the
-daemon spawns `claude -p` to do a rewrite, the spawned subprocess
-fires a Stop hook back into Heard. Without this latch we'd recurse.
-"""
+"""Stops the daemon from chasing its own tail when the CLI provider
+spawns `claude -p` and its Stop hook fires back into Heard."""
 
 from __future__ import annotations
 
@@ -12,32 +8,18 @@ import sys
 from heard import hook
 
 
-def test_main_exits_early_when_disabled(monkeypatch):
-    monkeypatch.setenv("HEARD_HOOK_DISABLED", "1")
+def test_hook_short_circuits_on_env_flag(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setitem(hook.AGENTS, "claude-code", lambda: calls.__setitem__("n", calls["n"] + 1))
     monkeypatch.setattr(sys, "argv", ["heard.hook", "claude-code"])
 
-    calls = {"n": 0}
-
-    def fake_cc():
-        calls["n"] += 1
-
-    monkeypatch.setitem(hook.AGENTS, "claude-code", fake_cc)
+    monkeypatch.setenv("HEARD_HOOK_DISABLED", "1")
     try:
         hook.main()
-    except SystemExit as e:
-        assert e.code == 0
+    except SystemExit:
+        pass
     assert calls["n"] == 0
 
-
-def test_main_dispatches_when_not_disabled(monkeypatch):
-    monkeypatch.delenv("HEARD_HOOK_DISABLED", raising=False)
-    monkeypatch.setattr(sys, "argv", ["heard.hook", "claude-code"])
-
-    calls = {"n": 0}
-
-    def fake_cc():
-        calls["n"] += 1
-
-    monkeypatch.setitem(hook.AGENTS, "claude-code", fake_cc)
+    monkeypatch.delenv("HEARD_HOOK_DISABLED")
     hook.main()
     assert calls["n"] == 1

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,120 @@
+"""Narration provider selection + CLI safety knobs."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from heard import providers
+
+
+def test_picks_api_provider_when_key_present(monkeypatch):
+    # Make the CLI also discoverable so we know the key is what's
+    # winning the selection, not "API key absent → CLI by default".
+    monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
+    p = providers.get_provider(api_key="sk-test")
+    assert isinstance(p, providers.AnthropicAPIProvider)
+
+
+def test_falls_back_to_cli_when_no_key(monkeypatch):
+    monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
+    p = providers.get_provider(api_key="")
+    assert isinstance(p, providers.ClaudeCLIProvider)
+
+
+def test_returns_none_when_no_key_and_no_cli(monkeypatch):
+    monkeypatch.setattr(providers, "_find_claude_binary", lambda: None)
+    assert providers.get_provider(api_key="") is None
+
+
+def test_blank_or_whitespace_key_falls_back_to_cli(monkeypatch):
+    monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
+    assert isinstance(providers.get_provider(api_key="   "), providers.ClaudeCLIProvider)
+    assert isinstance(providers.get_provider(api_key=""), providers.ClaudeCLIProvider)
+
+
+def test_cli_argv_disables_tools_and_session_persistence():
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    argv = p._build_argv(system="SYS", user="USR")
+    # Each flag exists, and the safety-critical ones are present:
+    assert argv[0] == "/fake/claude"
+    assert "-p" in argv
+    assert "--tools" in argv
+    # --tools must be followed by an empty string (disable all tools).
+    assert argv[argv.index("--tools") + 1] == ""
+    assert "--no-session-persistence" in argv
+    assert "--disable-slash-commands" in argv
+    # Skip the user-level settings.json where Heard's Stop hook lives.
+    assert "--setting-sources" in argv
+    assert argv[argv.index("--setting-sources") + 1] == "project"
+    # System prompt + user message land as the final args.
+    assert "--system-prompt" in argv
+    assert argv[argv.index("--system-prompt") + 1] == "SYS"
+    assert argv[-1] == "USR"
+
+
+def test_cli_env_sets_hook_disable_flag():
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    env = p._build_env()
+    assert env.get("HEARD_HOOK_DISABLED") == "1"
+
+
+def test_cli_env_drops_blank_anthropic_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    env = p._build_env()
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_cli_env_preserves_real_anthropic_key(monkeypatch):
+    # If the user has set a real key in env but somehow we still wound
+    # up in the CLI provider, don't clobber their key.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-real-key")
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    env = p._build_env()
+    assert env.get("ANTHROPIC_API_KEY") == "sk-real-key"
+
+
+def test_cli_rewrite_returns_stripped_stdout(monkeypatch):
+    captured = {}
+
+    def fake_run(argv, env=None, **kw):
+        captured["argv"] = argv
+        captured["env"] = env
+        captured["timeout"] = kw.get("timeout")
+        return SimpleNamespace(returncode=0, stdout="  hello there  \n", stderr="")
+
+    monkeypatch.setattr(providers.subprocess, "run", fake_run)
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    out = p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5)
+    assert out == "hello there"
+    # The 2.5s budget would kill every call given Node startup;
+    # the provider clamps up to its own floor.
+    assert captured["timeout"] >= providers.ClaudeCLIProvider.MIN_TIMEOUT_S
+
+
+def test_cli_rewrite_returns_none_on_timeout(monkeypatch):
+    def fake_run(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=kw.get("timeout", 0))
+
+    monkeypatch.setattr(providers.subprocess, "run", fake_run)
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    assert p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5) is None
+
+
+def test_cli_rewrite_returns_none_on_nonzero_exit(monkeypatch):
+    def fake_run(*a, **kw):
+        return SimpleNamespace(returncode=1, stdout="", stderr="auth failed")
+
+    monkeypatch.setattr(providers.subprocess, "run", fake_run)
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    assert p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5) is None
+
+
+def test_cli_rewrite_returns_none_on_empty_stdout(monkeypatch):
+    def fake_run(*a, **kw):
+        return SimpleNamespace(returncode=0, stdout="   \n", stderr="")
+
+    monkeypatch.setattr(providers.subprocess, "run", fake_run)
+    p = providers.ClaudeCLIProvider(binary="/fake/claude")
+    assert p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5) is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,120 +1,58 @@
-"""Narration provider selection + CLI safety knobs."""
+"""Narration provider selection + CLI safety."""
 
 from __future__ import annotations
 
 import subprocess
+import tempfile
 from types import SimpleNamespace
 
 from heard import providers
 
 
-def test_picks_api_provider_when_key_present(monkeypatch):
-    # Make the CLI also discoverable so we know the key is what's
-    # winning the selection, not "API key absent → CLI by default".
+def test_get_provider_picks_right_backend(monkeypatch):
     monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
-    p = providers.get_provider(api_key="sk-test")
-    assert isinstance(p, providers.AnthropicAPIProvider)
+    assert isinstance(providers.get_provider(api_key="sk-x"), providers.AnthropicAPIProvider)
+    assert isinstance(providers.get_provider(api_key=""), providers.ClaudeCLIProvider)
 
-
-def test_falls_back_to_cli_when_no_key(monkeypatch):
-    monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
-    p = providers.get_provider(api_key="")
-    assert isinstance(p, providers.ClaudeCLIProvider)
-
-
-def test_returns_none_when_no_key_and_no_cli(monkeypatch):
     monkeypatch.setattr(providers, "_find_claude_binary", lambda: None)
     assert providers.get_provider(api_key="") is None
 
 
-def test_blank_or_whitespace_key_falls_back_to_cli(monkeypatch):
-    monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
-    assert isinstance(providers.get_provider(api_key="   "), providers.ClaudeCLIProvider)
-    assert isinstance(providers.get_provider(api_key=""), providers.ClaudeCLIProvider)
-
-
-def test_cli_argv_disables_tools_and_session_persistence():
-    p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    argv = p._build_argv(system="SYS", user="USR")
-    # Each flag exists, and the safety-critical ones are present:
-    assert argv[0] == "/fake/claude"
-    assert "-p" in argv
-    assert "--tools" in argv
-    # --tools must be followed by an empty string (disable all tools).
-    assert argv[argv.index("--tools") + 1] == ""
-    assert "--no-session-persistence" in argv
-    assert "--disable-slash-commands" in argv
-    # Skip the user-level settings.json where Heard's Stop hook lives.
-    assert "--setting-sources" in argv
-    assert argv[argv.index("--setting-sources") + 1] == "project"
-    # System prompt + user message land as the final args.
-    assert "--system-prompt" in argv
-    assert argv[argv.index("--system-prompt") + 1] == "SYS"
-    assert argv[-1] == "USR"
-
-
-def test_cli_env_sets_hook_disable_flag():
-    p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    env = p._build_env()
-    assert env.get("HEARD_HOOK_DISABLED") == "1"
-
-
-def test_cli_env_drops_blank_anthropic_key(monkeypatch):
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
-    p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    env = p._build_env()
-    assert "ANTHROPIC_API_KEY" not in env
-
-
-def test_cli_env_preserves_real_anthropic_key(monkeypatch):
-    # If the user has set a real key in env but somehow we still wound
-    # up in the CLI provider, don't clobber their key.
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-real-key")
-    p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    env = p._build_env()
-    assert env.get("ANTHROPIC_API_KEY") == "sk-real-key"
-
-
-def test_cli_rewrite_returns_stripped_stdout(monkeypatch):
+def test_cli_subprocess_is_locked_down(monkeypatch):
+    """Verify the safety contract: no tool calls, user-level settings
+    skipped, hook latch set, and the subprocess runs from a tempdir so
+    project-local CLAUDE.md / .claude/ can't leak in."""
     captured = {}
 
-    def fake_run(argv, env=None, **kw):
-        captured["argv"] = argv
-        captured["env"] = env
-        captured["timeout"] = kw.get("timeout")
-        return SimpleNamespace(returncode=0, stdout="  hello there  \n", stderr="")
+    def fake_run(argv, env=None, cwd=None, **kw):
+        captured.update(argv=argv, env=env, cwd=cwd, timeout=kw.get("timeout"))
+        return SimpleNamespace(returncode=0, stdout="hi", stderr="")
 
     monkeypatch.setattr(providers.subprocess, "run", fake_run)
     p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    out = p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5)
-    assert out == "hello there"
-    # The 2.5s budget would kill every call given Node startup;
-    # the provider clamps up to its own floor.
+    p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5)
+
+    argv = captured["argv"]
+    assert argv[argv.index("--tools") + 1] == ""
+    assert argv[argv.index("--setting-sources") + 1] == "project"
+    assert captured["env"]["HEARD_HOOK_DISABLED"] == "1"
+    assert captured["cwd"] == tempfile.gettempdir()
     assert captured["timeout"] >= providers.ClaudeCLIProvider.MIN_TIMEOUT_S
 
 
-def test_cli_rewrite_returns_none_on_timeout(monkeypatch):
-    def fake_run(*a, **kw):
-        raise subprocess.TimeoutExpired(cmd="claude", timeout=kw.get("timeout", 0))
-
-    monkeypatch.setattr(providers.subprocess, "run", fake_run)
+def test_cli_returns_none_on_failure(monkeypatch):
+    """Any failure (timeout, non-zero, empty stdout) becomes None so
+    the persona layer falls back to templates instead of hanging."""
     p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    assert p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5) is None
 
+    def timeout(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=1)
 
-def test_cli_rewrite_returns_none_on_nonzero_exit(monkeypatch):
-    def fake_run(*a, **kw):
-        return SimpleNamespace(returncode=1, stdout="", stderr="auth failed")
+    monkeypatch.setattr(providers.subprocess, "run", timeout)
+    assert p.rewrite(system="s", user="u", max_tokens=80, timeout=1) is None
 
-    monkeypatch.setattr(providers.subprocess, "run", fake_run)
-    p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    assert p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5) is None
-
-
-def test_cli_rewrite_returns_none_on_empty_stdout(monkeypatch):
-    def fake_run(*a, **kw):
-        return SimpleNamespace(returncode=0, stdout="   \n", stderr="")
-
-    monkeypatch.setattr(providers.subprocess, "run", fake_run)
-    p = providers.ClaudeCLIProvider(binary="/fake/claude")
-    assert p.rewrite(system="SYS", user="USR", max_tokens=80, timeout=2.5) is None
+    monkeypatch.setattr(
+        providers.subprocess, "run",
+        lambda *a, **kw: SimpleNamespace(returncode=1, stdout="", stderr="x"),
+    )
+    assert p.rewrite(system="s", user="u", max_tokens=80, timeout=1) is None


### PR DESCRIPTION
## Summary

Heard's Haiku rewrite path required `ANTHROPIC_API_KEY`. Anyone using
Heard already has Claude Code installed (that's how the hooks land),
and Claude Code carries OAuth from the keychain. Use it as a fallback.

## Design

New `heard.providers` module splits the rewrite into two providers
behind one interface:

- `AnthropicAPIProvider` — current direct-HTTPS Haiku path.
- `ClaudeCLIProvider` — shells out to `claude -p`.

`persona.py` picks via `providers.get_provider(_anthropic_key())`:
API if a key is configured, else CLI if `claude` is on disk, else
`None` and we land on templates as today.

## Safety knobs on the CLI subprocess

- `--tools ""` — no tool calls fire, so no PreToolUse/PostToolUse
  hooks fire.
- `--setting-sources project` — skip `~/.claude/settings.json` where
  Heard's Stop hook lives.
- `HEARD_HOOK_DISABLED=1` in the child env. Belt-and-suspenders: even
  if Stop slips through, `heard.hook.main` short-circuits.
- `--no-session-persistence`, `--disable-slash-commands`.
- Timeout clamped to a `MIN_TIMEOUT_S = 8.0` floor — Node startup +
  auth verification blows past the 2.5s budget that works for HTTPS.
- Empty `ANTHROPIC_API_KEY` in env gets dropped so keychain OAuth is
  used cleanly.

## Test plan

- [x] Unit tests in `tests/test_providers.py` cover selection logic,
      argv shape, env scrubbing, timeout clamping, and the
      timeout/non-zero/empty failure paths.
- [x] Hook short-circuit covered in `tests/test_hook_disabled.py`.
- [x] End-to-end smoke: unset `ANTHROPIC_API_KEY` and call
      `providers.get_provider("").rewrite(...)` — returns a Haiku-style
      phrase in ~4s.
- [ ] Manual: install over a running Heard.app, clear the API key in
      Settings, run a Claude Code session and confirm narration still
      speaks instead of falling silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)