### PR TITLE
draft: fix(narration): wait for transcript flush in PreToolUse

### DIFF
--- a/heard/client.py
+++ b/heard/client.py
@@ -515,6 +515,10 @@ def handle_cc_pre_tool(data: dict) -> None:
     transcript = data.get("transcript_path")
     spoke_text = 0
     if transcript:
+        # Match Stop's flush wait — Claude Code may not have flushed the
+        # assistant-prose line to the transcript yet when this hook fires,
+        # so reading immediately misses prose written right before the tool.
+        time.sleep(cfg["flush_delay_ms"] / 1000.0)
         spoke_text = _speak_unspoken_texts(transcript, session, cfg, finalize=False)
 
     if spoke_text > 0:
@@ -598,6 +602,10 @@ def handle_codex_pre_tool(data: dict) -> None:
     transcript = data.get("transcript_path")
     spoke_text = 0
     if transcript:
+        # Match Stop's flush wait — Claude Code may not have flushed the
+        # assistant-prose line to the transcript yet when this hook fires,
+        # so reading immediately misses prose written right before the tool.
+        time.sleep(cfg["flush_delay_ms"] / 1000.0)
         spoke_text = _speak_unspoken_texts(transcript, session, cfg, finalize=False)
 
     if spoke_text > 0:


### PR DESCRIPTION
## Summary
- The Stop hook waits `flush_delay_ms` before reading the transcript because Claude Code / Codex don't necessarily flush the assistant-prose line to disk synchronously with the model output. PreToolUse was missing the same wait.
- Net effect: prose written immediately before a tool call (the preface to an `AskUserQuestion`, for instance) was often invisible at hook time and only got narrated on a later hook — by which point the user had already answered the question.
- Apply the same wait in `handle_cc_pre_tool` and `handle_codex_pre_tool`. One-line change in each, matching the existing intent on Stop.

## Test plan
- [x] `pytest -q` — 332 passed
- [x] `ruff check heard/client.py` — clean
- [ ] Hot-patch into running `Heard.app` and re-trigger an `AskUserQuestion` from a fresh Claude Code session; confirm the prose before the question gets narrated before the question UI returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)