### PR TITLE
feat(multi-agent): batch narration when events outpace speech

### DIFF
--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -205,24 +205,49 @@ class Daemon:
         )
 
     def _start_digest_timer(self) -> None:
-        """Periodic background-agent digest. Drains the router's
-        deferred events on every tick, formats a one-line summary,
-        and enqueues it as a synthetic intermediate event. No-op when
-        nothing's accumulated (solo-mode, idle, or feature off)."""
+        """Adaptive background-agent digest. The cadence flips based
+        on how many sessions are active:
+
+          - swarm (>=2 active): short interval (default 5s). The
+            digest IS the primary narration channel here — focus
+            speaking is suppressed in classify() so two agents can't
+            step on each other.
+          - solo (<2 active): long interval (default 60s). Anything
+            stashed from a recent swarm gets drained on a slow
+            heartbeat so nothing is left to rot.
+
+        No-op when nothing's accumulated."""
 
         def _tick() -> None:
             while True:
-                interval = float(self.cfg.get("multi_agent_digest_interval_s") or 60)
-                time.sleep(max(15.0, interval))
+                in_swarm = self.router.active_count() >= 2
+                if in_swarm:
+                    interval = float(
+                        self.cfg.get("multi_agent_swarm_digest_interval_s") or 5
+                    )
+                    interval = max(3.0, interval)
+                else:
+                    interval = float(
+                        self.cfg.get("multi_agent_digest_interval_s") or 60
+                    )
+                    interval = max(15.0, interval)
+                time.sleep(interval)
                 if not self.cfg.get("multi_agent_digest_enabled", True):
                     # Drop accumulated events silently — feature off.
                     self.router.collect_digest()
                     continue
                 drained = self.router.collect_digest()
-                summary = self.router.format_digest(drained)
+                summary = self.router.format_digest(
+                    drained, swarm_active=self.router.active_count() >= 2
+                )
                 if not summary:
                     continue
-                _log("digest_emit", chars=len(summary), sessions=len(drained))
+                _log(
+                    "digest_emit",
+                    chars=len(summary),
+                    sessions=len(drained),
+                    swarm=int(in_swarm),
+                )
                 # Use a "digest" session id so the router's own
                 # classify() doesn't try to suppress this. Voice falls
                 # through to the active persona/cfg.

--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -218,9 +218,20 @@ class Daemon:
 
         No-op when nothing's accumulated."""
 
+        def _is_batching() -> bool:
+            # Three ways to be in a swarm-like state: multiple top-level
+            # sessions active, one session with parallel subagents
+            # fanning out, or any session firing events fast enough to
+            # look like parallel agents. The digest timer reacts to any.
+            return (
+                self.router.active_count() >= 2
+                or self.router.peak_subagent_count() >= 2
+                or self.router.any_high_event_rate()
+            )
+
         def _tick() -> None:
             while True:
-                in_swarm = self.router.active_count() >= 2
+                in_swarm = _is_batching()
                 if in_swarm:
                     interval = float(
                         self.cfg.get("multi_agent_swarm_digest_interval_s") or 5
@@ -238,7 +249,7 @@ class Daemon:
                     continue
                 drained = self.router.collect_digest()
                 summary = self.router.format_digest(
-                    drained, swarm_active=self.router.active_count() >= 2
+                    drained, swarm_active=_is_batching()
                 )
                 if not summary:
                     continue
@@ -990,6 +1001,12 @@ class Daemon:
         session = self.sessions.touch(session_id, cwd=cwd)
         # Note this event so the router knows the session is active.
         self.router.note_event(session_id, cwd or "")
+        # An Agent tool kicking off means a subagent is starting. Track
+        # it so the router can detect parallel fan-out within ONE CC
+        # session (those subagents all share the parent session_id at
+        # the hook layer, so naive session counting misses them).
+        if kind == "tool_pre" and tag == "tool_agent":
+            self.router.note_subagent_start(session_id)
 
         if kind == "tool_pre":
             density = self.sessions.tool_density(session_id)

--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -218,20 +218,9 @@ class Daemon:
 
         No-op when nothing's accumulated."""
 
-        def _is_batching() -> bool:
-            # Three ways to be in a swarm-like state: multiple top-level
-            # sessions active, one session with parallel subagents
-            # fanning out, or any session firing events fast enough to
-            # look like parallel agents. The digest timer reacts to any.
-            return (
-                self.router.active_count() >= 2
-                or self.router.peak_subagent_count() >= 2
-                or self.router.any_high_event_rate()
-            )
-
         def _tick() -> None:
             while True:
-                in_swarm = _is_batching()
+                in_swarm = self.router.is_batching()
                 if in_swarm:
                     interval = float(
                         self.cfg.get("multi_agent_swarm_digest_interval_s") or 5
@@ -249,7 +238,7 @@ class Daemon:
                     continue
                 drained = self.router.collect_digest()
                 summary = self.router.format_digest(
-                    drained, swarm_active=_is_batching()
+                    drained, swarm_active=self.router.is_batching()
                 )
                 if not summary:
                     continue
@@ -999,14 +988,9 @@ class Daemon:
         cfg = config.load(cwd=cwd)
         persona = self._persona_for(cfg)
         session = self.sessions.touch(session_id, cwd=cwd)
-        # Note this event so the router knows the session is active.
+        # Note this event so the router knows the session is active
+        # and the rate window updates.
         self.router.note_event(session_id, cwd or "")
-        # An Agent tool kicking off means a subagent is starting. Track
-        # it so the router can detect parallel fan-out within ONE CC
-        # session (those subagents all share the parent session_id at
-        # the hook layer, so naive session counting misses them).
-        if kind == "tool_pre" and tag == "tool_agent":
-            self.router.note_subagent_start(session_id)
 
         if kind == "tool_pre":
             density = self.sessions.tool_density(session_id)

--- a/heard/multi_agent.py
+++ b/heard/multi_agent.py
@@ -1,28 +1,28 @@
 """Multi-agent routing.
 
-When more than one agent session fires events into the daemon
-concurrently — say three Claude Code instances running in three
-Ghostty tabs — naive per-event narration becomes incoherent: the
-listener hears half-sentences from each agent, bouncing.
+One rule: speech is serial — one utterance at a time, ~1 s minimum —
+so when events arrive faster than we can physically speak them, we
+batch. That single signal handles every "N agents talking at once"
+scenario: two CC instances in two terminals, one CC fanning out via
+the Agent tool, or a single agent on a bursty stretch of tool calls.
 
-This module classifies each event into one of three actions:
+Events are classified into three actions:
 
   speak           — go through the queue normally
-  drop            — silent (routine narration from a non-focus agent)
-  defer_to_digest — batch for the digest timer, which combines events
-                    from all active agents into a single spoken line
-                    per window
+  drop            — silent (only used in pinned mode)
+  defer_to_digest — batch into the per-session pile, drained by the
+                    daemon's digest timer
 
-Three modes, picked automatically:
+Three modes:
 
-  SOLO    — only one session active in the last SESSION_ACTIVE_S.
-            Everything plays. Today's behaviour.
-  SWARM   — 2+ active sessions. Every non-pierce event batches into
-            the digest pile; the daemon drains it on a fast cadence
-            (a few seconds) and produces one combined line per window
-            so two agents can't speak over each other. Failures and
-            wait-state questions still pierce immediately with an
-            "Agent <name>:" prefix so urgent events cut through.
+  SOLO    — under the rate threshold. Everything plays live.
+  SWARM   — over the rate threshold. Routine tool events batch into
+            the digest pile; finals + intermediates speak with the
+            speaker-change label so the agent's actual prose isn't
+            lost; failures + questions always pierce with an
+            "Agent <name>:" prefix. The daemon's digest timer drains
+            the pile every few seconds with per-session labels
+            preserved.
   PINNED  — user explicitly picked one session to follow. Only that
             session's events narrate; others drop, except again
             failures/questions pierce with prefix.
@@ -81,24 +81,16 @@ SESSION_ACTIVE_S = 180.0
 # user pin a session that just went idle for a moment.
 SESSION_VISIBLE_S = 600.0
 
-# Recent Agent-tool invocations are remembered for this long when
-# counting parallel subagents within one CC session. The hook fires
-# on PreToolUse(Agent) but the matching PostToolUse for a successful
-# Agent call is silent (templates.post_tool_event returns None on
-# success), so we can't decrement on completion — we just expire
-# entries after this window. 300 s is long enough to span a typical
-# multi-minute subagent run but short enough that "did three quick
-# Agents an hour ago" doesn't keep us in batch mode forever.
-SUBAGENT_TRACK_WINDOW_S = 300.0
-
-# Per-session event-rate detection. A single sequential agent rarely
-# fires more than ~1 event per second during active tool use;
-# sustained bursts well above that point at parallel agents under one
-# CC session_id (e.g. a fan-out we can't see from the Agent-tool
-# signal alone). When the window is busy, we treat that session as
-# swarm-equivalent. The threshold is intentionally a bit forgiving
-# — false positives just mean a brief burst gets batched, which is
-# fine; false negatives leave the listener hearing N agents at once.
+# Rate-based batching. Speech is fundamentally serial — one utterance
+# at a time, ~1 s minimum — so when events arrive faster than we can
+# physically speak them, the only sane response is to batch. That
+# signal is also what makes multi-agent narration coherent: whether
+# it's two CC instances in two terminals or one CC session fanning
+# out via the Agent tool, the symptom is the same (events firing
+# faster than ~1/s). One rule covers both — count events in a short
+# rolling window, batch when over threshold. Tune is per-installation
+# via config; defaults are 6 events in 3 s, which a sequential agent
+# won't sustain but parallel narrators will trip immediately.
 EVENT_RATE_WINDOW_S = 3.0
 EVENT_RATE_THRESHOLD = 6
 
@@ -129,16 +121,6 @@ class SessionInfo:
     # events on a fast machine) so "most recent" is deterministic.
     event_seq: int = 0
     pending_digest: list[dict[str, Any]] = field(default_factory=list)
-    # Timestamps of recent Agent-tool invocations for this session.
-    # Used to detect parallel subagent fan-out within one CC session
-    # (the hook payloads from subagents all carry the parent's
-    # session_id, so we'd otherwise see only one busy agent).
-    subagent_starts: list[float] = field(default_factory=list)
-    # Rolling-window timestamps of every event from this session.
-    # Lets us catch fan-out we couldn't see from the Agent-tool
-    # signal alone — when a single session_id fires events faster
-    # than a sequential agent ever would, it's parallel narration.
-    recent_event_times: list[float] = field(default_factory=list)
 
 
 @dataclass
@@ -230,6 +212,12 @@ class MultiAgentRouter:
         # the speaker *changes* — narrating ten lines in a row from the
         # agent you're driving shouldn't read its name ten times.
         self._last_narrated_session: str | None = None
+        # Rolling window of every event timestamp across all sessions.
+        # When this exceeds EVENT_RATE_THRESHOLD inside EVENT_RATE_WINDOW_S
+        # we're producing narration faster than we can physically speak
+        # — batch the noise. One signal covers every "N agents are
+        # talking at once" scenario.
+        self._event_times: list[float] = []
 
     # --- session tracking --------------------------------------------------
 
@@ -255,11 +243,14 @@ class MultiAgentRouter:
             now = time.time()
             info.last_event = now
             info.event_seq = self._event_counter
+            # Bump the global rate window. Inter-session by design:
+            # two sessions each at moderate rate will combine here
+            # and trip the threshold together, which is exactly what
+            # we want — the listener can only consume one voice
+            # stream, no matter where the events come from.
             rate_cutoff = now - EVENT_RATE_WINDOW_S
-            info.recent_event_times = [
-                t for t in info.recent_event_times if t >= rate_cutoff
-            ]
-            info.recent_event_times.append(now)
+            self._event_times = [t for t in self._event_times if t >= rate_cutoff]
+            self._event_times.append(now)
 
     def _active_locked(self, now: float) -> list[SessionInfo]:
         cutoff = now - SESSION_ACTIVE_S
@@ -269,75 +260,21 @@ class MultiAgentRouter:
         with self._lock:
             if self._pinned and self._pinned in self._sessions:
                 return Mode.PINNED
-            return Mode.SWARM if len(self._active_locked(time.time())) >= 2 else Mode.SOLO
+            return Mode.SWARM if self._is_batching_locked() else Mode.SOLO
 
-    def active_count(self) -> int:
-        """How many sessions have fired an event within
-        ``SESSION_ACTIVE_S``. Used by the daemon to pick a fast
-        digest cadence while a swarm is in flight and a slow one
-        when things go quiet."""
-        with self._lock:
-            return len(self._active_locked(time.time()))
-
-    def note_subagent_start(self, session_id: str) -> None:
-        """Record that this session just kicked off an Agent-tool call.
-        Called by the daemon when a ``tool_agent`` pre-event arrives.
-        The session must already exist (note_event runs first)."""
-        with self._lock:
-            info = self._sessions.get(session_id)
-            if info is None:
-                return
-            cutoff = time.time() - SUBAGENT_TRACK_WINDOW_S
-            info.subagent_starts = [t for t in info.subagent_starts if t >= cutoff]
-            info.subagent_starts.append(time.time())
-
-    def _subagent_count_locked(self, session_id: str) -> int:
-        info = self._sessions.get(session_id)
-        if info is None:
-            return 0
-        cutoff = time.time() - SUBAGENT_TRACK_WINDOW_S
-        info.subagent_starts = [t for t in info.subagent_starts if t >= cutoff]
-        return len(info.subagent_starts)
-
-    def subagent_count(self, session_id: str) -> int:
-        with self._lock:
-            return self._subagent_count_locked(session_id)
-
-    def peak_subagent_count(self) -> int:
-        """Max parallel subagents across all active sessions. The
-        daemon uses this alongside active_count() to decide whether
-        the digest timer should run on its fast cadence."""
-        with self._lock:
-            cutoff = time.time() - SUBAGENT_TRACK_WINDOW_S
-            peak = 0
-            for info in self._sessions.values():
-                info.subagent_starts = [t for t in info.subagent_starts if t >= cutoff]
-                if len(info.subagent_starts) > peak:
-                    peak = len(info.subagent_starts)
-            return peak
-
-    def _high_event_rate_locked(self, session_id: str) -> bool:
-        """True when this session has fired more than
-        ``EVENT_RATE_THRESHOLD`` events in the last
-        ``EVENT_RATE_WINDOW_S``. A sequential agent rarely sustains
-        that rate; bursts past it are almost always parallel agents
-        under one session_id."""
-        info = self._sessions.get(session_id)
-        if info is None:
-            return False
+    def _is_batching_locked(self) -> bool:
         cutoff = time.time() - EVENT_RATE_WINDOW_S
-        info.recent_event_times = [t for t in info.recent_event_times if t >= cutoff]
-        return len(info.recent_event_times) >= EVENT_RATE_THRESHOLD
+        self._event_times = [t for t in self._event_times if t >= cutoff]
+        return len(self._event_times) >= EVENT_RATE_THRESHOLD
 
-    def any_high_event_rate(self) -> bool:
-        """True when ANY active session is firing fast enough to look
-        like parallel agents. The daemon checks this to flip the
-        digest cadence to its fast tick."""
+    def is_batching(self) -> bool:
+        """True when events are arriving faster than we can physically
+        speak them. The router defers routine events to the digest and
+        the daemon picks a fast digest cadence — both keyed off this
+        one signal. Inter-session: counts across all sessions, since
+        the listener is the bottleneck regardless of source."""
         with self._lock:
-            for sid in list(self._sessions.keys()):
-                if self._high_event_rate_locked(sid):
-                    return True
-            return False
+            return self._is_batching_locked()
 
     # --- routing -----------------------------------------------------------
 
@@ -377,23 +314,8 @@ class MultiAgentRouter:
                     return self._speaking_locked(session_id, self._pierced(session_id, voice))
                 return RoutingDecision(action="drop")
 
-            active = self._active_locked(now)
-            # "In a swarm-like environment" — any of:
-            #   - multiple top-level sessions active (two CC instances
-            #     in two terminals)
-            #   - this session has parallel subagents in flight (one
-            #     CC session fanning out via the Agent tool — shares
-            #     one session_id at the hook layer)
-            #   - this session is firing events faster than a
-            #     sequential agent ever would (catches parallel
-            #     fan-out we couldn't see from the Agent signal alone)
-            in_swarm = (
-                len(active) >= 2
-                or self._subagent_count_locked(session_id) >= 2
-                or self._high_event_rate_locked(session_id)
-            )
-            # Solo: not in a swarm-like state, today's behaviour, everything plays.
-            if not in_swarm:
+            # Under-rate: just speak it live, the usual UX.
+            if not self._is_batching_locked():
                 voice = self._voice_for_locked(
                     session_id, agent_voices, auto_voices, is_focus=True
                 )
@@ -401,24 +323,15 @@ class MultiAgentRouter:
                     session_id, RoutingDecision(action="speak", voice_override=voice)
                 )
 
-            # Swarm: >=2 active. The old "most recently active speaks"
-            # heuristic flipped focus on every event from two busy
-            # agents, so the listener heard them stepping on each
-            # other. Split by kind instead:
-            #
-            #   - Pierces (failures, questions) cut through with an
-            #     explicit "Agent <name>:" label — urgent events
-            #     should always announce who, even if the same agent
-            #     was the last speaker.
-            #   - Finals + intermediates SPEAK with the speaker-change
-            #     label (silent prefix when consecutive lines come
-            #     from the same agent in one-voice mode). The agent's
-            #     actual prose isn't reduced to a tag count, but the
-            #     listener doesn't hear the name on every line either.
-            #   - Routine tool events batch into the digest pile; the
-            #     daemon's fast digest timer (cadence chosen by
-            #     active_count) drains them as one combined count line
-            #     per window. This is where the noise lives.
+            # Over-rate: the listener can't keep up. Three lanes:
+            #   - Pierces (failures, questions) always cut through
+            #     with an "Agent <name>:" label.
+            #   - Finals + intermediates speak with the speaker-change
+            #     label so prose content survives but consecutive lines
+            #     from one agent don't redundantly announce its name.
+            #   - Everything else batches into the digest pile, which
+            #     the daemon drains every few seconds with per-session
+            #     labels preserved.
             if tag in _PIERCE_TAGS:
                 voice = self._voice_for_locked(
                     session_id, agent_voices, auto_voices, is_focus=False
@@ -455,16 +368,15 @@ class MultiAgentRouter:
         auto_voices: bool,
         now: float,
     ) -> str:
-        """"Agent <name>: " prefix for the focused agent's narration when
-        there's no other way to tell agents apart by sound — i.e. the
-        single-voice multi-agent mode (auto_voices off, no manual voice
-        for this repo). Empty when:
+        """"Agent <name>: " prefix for narration when there's no other
+        way to tell agents apart by sound — i.e. the single-voice mode
+        (auto_voices off, no manual voice for this repo). Empty when:
           - only one active agent (no ambiguity),
           - this agent has a distinct voice (auto-pool or manual map),
-          - this agent already spoke last (don't re-announce its name on
-            every consecutive line — only on a speaker change).
-        Must be called with ``self._lock`` held, *before* the speaker is
-        recorded via ``_speaking_locked``."""
+          - this agent already spoke last (don't re-announce its name
+            on every consecutive line — only on a speaker change).
+        Must be called with ``self._lock`` held, *before* the speaker
+        is recorded via ``_speaking_locked``."""
         if len(self._active_locked(now)) < 2:
             return ""
         if auto_voices:

--- a/heard/multi_agent.py
+++ b/heard/multi_agent.py
@@ -9,18 +9,20 @@ This module classifies each event into one of three actions:
 
   speak           — go through the queue normally
   drop            — silent (routine narration from a non-focus agent)
-  defer_to_digest — accumulate for a periodic summary (commit B wires
-                    the timer; commit A leaves these accumulating for
-                    a no-op consumer)
+  defer_to_digest — batch for the digest timer, which combines events
+                    from all active agents into a single spoken line
+                    per window
 
 Three modes, picked automatically:
 
   SOLO    — only one session active in the last SESSION_ACTIVE_S.
             Everything plays. Today's behaviour.
-  SWARM   — 2+ active sessions. Most-recently-active gets full
-            narration; others' routine events drop, but failures and
-            wait-state questions pierce with an "Agent <name>:"
-            prefix so the user can hear who.
+  SWARM   — 2+ active sessions. Every non-pierce event batches into
+            the digest pile; the daemon drains it on a fast cadence
+            (a few seconds) and produces one combined line per window
+            so two agents can't speak over each other. Failures and
+            wait-state questions still pierce immediately with an
+            "Agent <name>:" prefix so urgent events cut through.
   PINNED  — user explicitly picked one session to follow. Only that
             session's events narrate; others drop, except again
             failures/questions pierce with prefix.
@@ -63,11 +65,16 @@ def _auto_voice_for(repo_name: str) -> str:
     digest = hashlib.sha1(repo_name.encode("utf-8")).hexdigest()
     return _AUTO_VOICE_POOL[int(digest, 16) % len(_AUTO_VOICE_POOL)]
 
-# How long after the last event a session counts as "active". Used
-# both for the SOLO/SWARM mode decision and for the menu's active-
-# sessions list. 30 s is roughly "I just ran a thing, the agent's
-# still cooking".
-SESSION_ACTIVE_S = 30.0
+# How long after the last event a session counts as "active" for the
+# SOLO/SWARM decision. Was 30 s — that's "currently cooking" and
+# undercounted multi-agent setups where the user is rotating between
+# terminals (agent A runs for 20 s, goes quiet while the user reads,
+# user prompts agent B; from the router's view only one is "active"
+# at any moment and it stays in SOLO so events speak live and step on
+# each other). 180 s captures bursty rotation patterns — if you've
+# touched an agent in the last few minutes, it counts as running and
+# the batching kicks in implicitly.
+SESSION_ACTIVE_S = 180.0
 
 # Show a session in active_sessions() for this long after its last
 # event, even if it's no longer "active" for mode purposes. Lets the
@@ -227,6 +234,14 @@ class MultiAgentRouter:
                 return Mode.PINNED
             return Mode.SWARM if len(self._active_locked(time.time())) >= 2 else Mode.SOLO
 
+    def active_count(self) -> int:
+        """How many sessions have fired an event within
+        ``SESSION_ACTIVE_S``. Used by the daemon to pick a fast
+        digest cadence while a swarm is in flight and a slow one
+        when things go quiet."""
+        with self._lock:
+            return len(self._active_locked(time.time()))
+
     # --- routing -----------------------------------------------------------
 
     def classify(
@@ -275,11 +290,30 @@ class MultiAgentRouter:
                     session_id, RoutingDecision(action="speak", voice_override=voice)
                 )
 
-            # Swarm: >=2 active. Most-recently-active wins; others
-            # pierce only on critical tags, otherwise digest-defer.
-            most_recent = max(active, key=lambda s: (s.last_event, s.event_seq))
-            is_focus = session_id == most_recent.session_id
-            if is_focus:
+            # Swarm: >=2 active. The old "most recently active speaks"
+            # heuristic flipped focus on every event from two busy
+            # agents, so the listener heard them stepping on each
+            # other. Split by kind instead:
+            #
+            #   - Pierces (failures, questions) cut through with an
+            #     explicit "Agent <name>:" label — urgent events
+            #     should always announce who, even if the same agent
+            #     was the last speaker.
+            #   - Finals + intermediates SPEAK with the speaker-change
+            #     label (silent prefix when consecutive lines come
+            #     from the same agent in one-voice mode). The agent's
+            #     actual prose isn't reduced to a tag count, but the
+            #     listener doesn't hear the name on every line either.
+            #   - Routine tool events batch into the digest pile; the
+            #     daemon's fast digest timer (cadence chosen by
+            #     active_count) drains them as one combined count line
+            #     per window. This is where the noise lives.
+            if tag in _PIERCE_TAGS:
+                voice = self._voice_for_locked(
+                    session_id, agent_voices, auto_voices, is_focus=False
+                )
+                return self._speaking_locked(session_id, self._pierced(session_id, voice))
+            if kind in ("final", "intermediate"):
                 voice = self._voice_for_locked(
                     session_id, agent_voices, auto_voices, is_focus=True
                 )
@@ -293,11 +327,6 @@ class MultiAgentRouter:
                         ),
                     ),
                 )
-            if tag in _PIERCE_TAGS:
-                voice = self._voice_for_locked(
-                    session_id, agent_voices, auto_voices, is_focus=False
-                )
-                return self._speaking_locked(session_id, self._pierced(session_id, voice))
             return RoutingDecision(action="defer_to_digest")
 
     def _speaking_locked(self, session_id: str, decision: RoutingDecision) -> RoutingDecision:
@@ -455,13 +484,21 @@ class MultiAgentRouter:
     def format_digest(
         self,
         drained: list[tuple[SessionInfo, list[dict[str, Any]]]] | None = None,
+        swarm_active: bool = False,
     ) -> str | None:
         """Roll the per-session pending events into a single spoken
         line. Returns None when there's nothing to say (no events
         accumulated since last drain).
 
         ``drained`` is the output of ``collect_digest()``; passed in
-        explicitly so the daemon controls when accumulation resets."""
+        explicitly so the daemon controls when accumulation resets.
+
+        ``swarm_active`` toggles the "Background update." preface.
+        When swarm is on, the digest is firing every few seconds as
+        the *primary* narration channel, and prepending "Background
+        update." each cycle sounds like a stuck record. When swarm
+        is off it's a true ambient catch-up and keeping the preface
+        makes the role of the line clearer to the listener."""
         if drained is None:
             drained = self.collect_digest()
         parts = []
@@ -471,7 +508,8 @@ class MultiAgentRouter:
                 parts.append(piece)
         if not parts:
             return None
-        return "Background update. " + " ".join(parts)
+        body = " ".join(parts)
+        return body if swarm_active else "Background update. " + body
 
     def list_active(self) -> list[dict[str, Any]]:
         """Snapshot for the menu's Active Sessions submenu. Includes

--- a/heard/multi_agent.py
+++ b/heard/multi_agent.py
@@ -81,6 +81,27 @@ SESSION_ACTIVE_S = 180.0
 # user pin a session that just went idle for a moment.
 SESSION_VISIBLE_S = 600.0
 
+# Recent Agent-tool invocations are remembered for this long when
+# counting parallel subagents within one CC session. The hook fires
+# on PreToolUse(Agent) but the matching PostToolUse for a successful
+# Agent call is silent (templates.post_tool_event returns None on
+# success), so we can't decrement on completion — we just expire
+# entries after this window. 300 s is long enough to span a typical
+# multi-minute subagent run but short enough that "did three quick
+# Agents an hour ago" doesn't keep us in batch mode forever.
+SUBAGENT_TRACK_WINDOW_S = 300.0
+
+# Per-session event-rate detection. A single sequential agent rarely
+# fires more than ~1 event per second during active tool use;
+# sustained bursts well above that point at parallel agents under one
+# CC session_id (e.g. a fan-out we can't see from the Agent-tool
+# signal alone). When the window is busy, we treat that session as
+# swarm-equivalent. The threshold is intentionally a bit forgiving
+# — false positives just mean a brief burst gets batched, which is
+# fine; false negatives leave the listener hearing N agents at once.
+EVENT_RATE_WINDOW_S = 3.0
+EVENT_RATE_THRESHOLD = 6
+
 # Tags that always pierce regardless of mode/focus — the "name across
 # the room" signal. Failures and wait-state questions are events the
 # user must hear even from background agents.
@@ -108,6 +129,16 @@ class SessionInfo:
     # events on a fast machine) so "most recent" is deterministic.
     event_seq: int = 0
     pending_digest: list[dict[str, Any]] = field(default_factory=list)
+    # Timestamps of recent Agent-tool invocations for this session.
+    # Used to detect parallel subagent fan-out within one CC session
+    # (the hook payloads from subagents all carry the parent's
+    # session_id, so we'd otherwise see only one busy agent).
+    subagent_starts: list[float] = field(default_factory=list)
+    # Rolling-window timestamps of every event from this session.
+    # Lets us catch fan-out we couldn't see from the Agent-tool
+    # signal alone — when a single session_id fires events faster
+    # than a sequential agent ever would, it's parallel narration.
+    recent_event_times: list[float] = field(default_factory=list)
 
 
 @dataclass
@@ -221,8 +252,14 @@ class MultiAgentRouter:
                 )
                 self._sessions[session_id] = info
             self._event_counter += 1
-            info.last_event = time.time()
+            now = time.time()
+            info.last_event = now
             info.event_seq = self._event_counter
+            rate_cutoff = now - EVENT_RATE_WINDOW_S
+            info.recent_event_times = [
+                t for t in info.recent_event_times if t >= rate_cutoff
+            ]
+            info.recent_event_times.append(now)
 
     def _active_locked(self, now: float) -> list[SessionInfo]:
         cutoff = now - SESSION_ACTIVE_S
@@ -241,6 +278,66 @@ class MultiAgentRouter:
         when things go quiet."""
         with self._lock:
             return len(self._active_locked(time.time()))
+
+    def note_subagent_start(self, session_id: str) -> None:
+        """Record that this session just kicked off an Agent-tool call.
+        Called by the daemon when a ``tool_agent`` pre-event arrives.
+        The session must already exist (note_event runs first)."""
+        with self._lock:
+            info = self._sessions.get(session_id)
+            if info is None:
+                return
+            cutoff = time.time() - SUBAGENT_TRACK_WINDOW_S
+            info.subagent_starts = [t for t in info.subagent_starts if t >= cutoff]
+            info.subagent_starts.append(time.time())
+
+    def _subagent_count_locked(self, session_id: str) -> int:
+        info = self._sessions.get(session_id)
+        if info is None:
+            return 0
+        cutoff = time.time() - SUBAGENT_TRACK_WINDOW_S
+        info.subagent_starts = [t for t in info.subagent_starts if t >= cutoff]
+        return len(info.subagent_starts)
+
+    def subagent_count(self, session_id: str) -> int:
+        with self._lock:
+            return self._subagent_count_locked(session_id)
+
+    def peak_subagent_count(self) -> int:
+        """Max parallel subagents across all active sessions. The
+        daemon uses this alongside active_count() to decide whether
+        the digest timer should run on its fast cadence."""
+        with self._lock:
+            cutoff = time.time() - SUBAGENT_TRACK_WINDOW_S
+            peak = 0
+            for info in self._sessions.values():
+                info.subagent_starts = [t for t in info.subagent_starts if t >= cutoff]
+                if len(info.subagent_starts) > peak:
+                    peak = len(info.subagent_starts)
+            return peak
+
+    def _high_event_rate_locked(self, session_id: str) -> bool:
+        """True when this session has fired more than
+        ``EVENT_RATE_THRESHOLD`` events in the last
+        ``EVENT_RATE_WINDOW_S``. A sequential agent rarely sustains
+        that rate; bursts past it are almost always parallel agents
+        under one session_id."""
+        info = self._sessions.get(session_id)
+        if info is None:
+            return False
+        cutoff = time.time() - EVENT_RATE_WINDOW_S
+        info.recent_event_times = [t for t in info.recent_event_times if t >= cutoff]
+        return len(info.recent_event_times) >= EVENT_RATE_THRESHOLD
+
+    def any_high_event_rate(self) -> bool:
+        """True when ANY active session is firing fast enough to look
+        like parallel agents. The daemon checks this to flip the
+        digest cadence to its fast tick."""
+        with self._lock:
+            for sid in list(self._sessions.keys()):
+                if self._high_event_rate_locked(sid):
+                    return True
+            return False
 
     # --- routing -----------------------------------------------------------
 
@@ -281,8 +378,22 @@ class MultiAgentRouter:
                 return RoutingDecision(action="drop")
 
             active = self._active_locked(now)
-            # Solo: <2 active sessions, today's behaviour, everything plays.
-            if len(active) < 2:
+            # "In a swarm-like environment" — any of:
+            #   - multiple top-level sessions active (two CC instances
+            #     in two terminals)
+            #   - this session has parallel subagents in flight (one
+            #     CC session fanning out via the Agent tool — shares
+            #     one session_id at the hook layer)
+            #   - this session is firing events faster than a
+            #     sequential agent ever would (catches parallel
+            #     fan-out we couldn't see from the Agent signal alone)
+            in_swarm = (
+                len(active) >= 2
+                or self._subagent_count_locked(session_id) >= 2
+                or self._high_event_rate_locked(session_id)
+            )
+            # Solo: not in a swarm-like state, today's behaviour, everything plays.
+            if not in_swarm:
                 voice = self._voice_for_locked(
                     session_id, agent_voices, auto_voices, is_focus=True
                 )

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,12 +1,15 @@
 """Multi-agent router tests.
 
-Three scenarios drive the design:
-  - Solo: one CC instance, today's UX, everything plays.
-  - Swarm: 2+ instances active concurrently. Every non-pierce event
-    batches into the digest pile; the daemon's adaptive digest timer
-    drains it as one combined line per window. Failures/questions
-    pierce with an agent label so urgent events still cut through.
-  - Pinned: user explicitly chose one to follow. Only that session
+One rule drives the design now: speech is serial, so when events fire
+faster than we can speak them we batch. Inter-session by construction
+— the rolling event window counts across all sessions.
+
+Three modes:
+  - Solo / under-rate: everything plays live.
+  - Batching (Mode.SWARM): rate-trip. Routine tool events defer to the
+    digest pile; finals/intermediates speak with the speaker-change
+    label; failures/questions pierce with an agent label.
+  - Pinned: user explicitly chose one to follow; only that session
     plays unconditionally; others pierce on critical only.
 """
 
@@ -21,6 +24,17 @@ def _new_router() -> multi_agent.MultiAgentRouter:
     return multi_agent.MultiAgentRouter()
 
 
+def _trip_batching(r: multi_agent.MultiAgentRouter, sessions: tuple[str, ...] = ("a", "b")) -> None:
+    """Push the router past the rate threshold by firing alternating
+    note_events across the given sessions. Lets a test set up a
+    batching scenario without depending on real-time waits."""
+    # +1 ensures the rolling-window count strictly exceeds the threshold.
+    total = multi_agent.EVENT_RATE_THRESHOLD + 1
+    for i in range(total):
+        r.note_event(sessions[i % len(sessions)])
+    assert r.is_batching() is True
+
+
 def test_solo_mode_speaks_everything():
     r = _new_router()
     r.note_event("only-session", cwd="/Users/x/projects/api")
@@ -32,29 +46,27 @@ def test_solo_mode_speaks_everything():
     assert r.mode() == multi_agent.Mode.SOLO
 
 
-def test_swarm_defers_all_non_pierce_events():
-    """Two active sessions: every routine event defers to the digest
-    regardless of who fired most recently. The old "most-recently-
-    active speaks" behaviour caused two busy agents to trade speakers
-    on every event and step on each other."""
+def test_batching_defers_routine_events():
+    """Past the rate threshold, every routine tool event defers to the
+    digest — regardless of which session fired it. Inter-session: the
+    combined rate is what matters, not any one session's tempo."""
     r = _new_router()
     r.note_event("a", cwd="/Users/x/projects/api")
     r.note_event("b", cwd="/Users/x/projects/web")
+    _trip_batching(r, ("a", "b"))
 
     assert r.mode() == multi_agent.Mode.SWARM
-    a_decision = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a")
-    b_decision = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b")
-    assert a_decision.action == "defer_to_digest"
-    assert b_decision.action == "defer_to_digest"
+    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
+    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
 
 
-def test_swarm_critical_pierces_with_label():
-    """Failures + questions from any session in swarm still narrate,
-    prefixed with the agent label so urgent events cut through the
-    batched digest."""
+def test_batching_pierces_critical_with_label():
+    """When batching, failures + questions cut through with an agent
+    label so urgent events aren't lost in the digest."""
     r = _new_router()
     r.note_event("a", cwd="/Users/x/projects/api")
     r.note_event("b", cwd="/Users/x/projects/web")
+    _trip_batching(r, ("a", "b"))
 
     fail_a = r.classify(kind="tool_post", tag="tool_post_failure", session_id="a")
     assert fail_a.action == "speak"
@@ -65,19 +77,18 @@ def test_swarm_critical_pierces_with_label():
     assert "api" in q_a.label_prefix
 
 
-def test_swarm_does_not_flip_focus_on_event_burst():
-    """Regression guard: a tight burst of alternating events from two
-    agents used to flip the live speaker on every event, which sounded
-    like two voices on top of each other. Now both stay batched."""
+def test_batching_inter_session_combines_rates():
+    """Two sessions each below the threshold on their own can combine
+    over the threshold — and batching should trip together. This is
+    the multi-CC-terminal case."""
     r = _new_router()
-    r.note_event("a")
-    time.sleep(0.01)
-    r.note_event("b")
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
-
-    time.sleep(0.01)
-    r.note_event("a")
+    # Half the threshold from each session — neither alone trips.
+    half = multi_agent.EVENT_RATE_THRESHOLD // 2 + 1
+    for _ in range(half):
+        r.note_event("a")
+    for _ in range(half):
+        r.note_event("b")
+    assert r.is_batching() is True
     assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
     assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
 
@@ -109,8 +120,7 @@ def test_pinned_critical_still_pierces_from_others():
 
 def test_unpin_returns_to_auto_mode():
     r = _new_router()
-    r.note_event("a")
-    r.note_event("b")
+    _trip_batching(r)
     r.pin("a")
     assert r.mode() == multi_agent.Mode.PINNED
     r.unpin()
@@ -123,15 +133,14 @@ def test_pin_unknown_session_returns_false():
     assert r.pinned_session_id() is None
 
 
-def test_solo_after_inactive_threshold():
-    """If only one session has been active in the SESSION_ACTIVE_S
-    window, mode is solo even with stale entries lingering."""
+def test_solo_when_under_rate():
+    """Under the rate threshold, mode is solo and routine events speak
+    live — even with multiple sessions registered."""
     r = _new_router()
     r.note_event("a")
-    # Manually backdate b past the active threshold.
     r.note_event("b")
-    r._sessions["b"].last_event = time.time() - multi_agent.SESSION_ACTIVE_S - 5
 
+    assert r.is_batching() is False
     assert r.mode() == multi_agent.Mode.SOLO
     assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "speak"
 
@@ -178,9 +187,10 @@ def test_agent_voices_override_on_pierce_too():
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
     voices = {"api": "voice_id_api"}
 
-    # a is non-focus; failure should pierce with both label and voice.
+    # Failure should pierce with both label and voice.
     da_fail = r.classify(
         kind="tool_post", tag="tool_post_failure",
         session_id="a", agent_voices=voices,
@@ -214,22 +224,20 @@ def test_format_digest_returns_none_when_empty():
     assert r.format_digest() is None
 
 
-def test_auto_voices_pick_distinct_for_non_focus_in_swarm():
-    """auto_voices=True: non-focus sessions in swarm get hash-picked
-    voices from the pool. Same repo_name → same voice across runs."""
+def test_auto_voices_pick_distinct_for_non_focus_when_batching():
+    """auto_voices=True under batching: routine tool events defer;
+    pierces speak with a hash-picked voice from the pool."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
-    # b is focus.
+    _trip_batching(r, ("a", "b"))
 
     da = r.classify(
         kind="tool_pre", tag="tool_bash_grep", session_id="a",
         auto_voices=True,
     )
-    # Non-focus → defer (not pierce), no voice override on a defer.
     assert da.action == "defer_to_digest"
 
-    # But on a pierce (failure), non-focus gets auto-picked voice.
     da_fail = r.classify(
         kind="tool_post", tag="tool_post_failure", session_id="a",
         auto_voices=True,
@@ -247,11 +255,12 @@ def test_auto_voices_pick_distinct_for_non_focus_in_swarm():
 
 
 def test_auto_voices_off_keeps_persona_voice():
-    """auto_voices=False: non-focus sessions get None voice_override
-    (caller falls through to persona / cfg)."""
+    """auto_voices=False during batching: pierces speak with None
+    voice_override (caller falls through to persona / cfg)."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
 
     da_fail = r.classify(
         kind="tool_post", tag="tool_post_failure", session_id="a",
@@ -274,13 +283,16 @@ def test_auto_voices_does_not_override_focus_or_solo():
     )
     assert d.voice_override is None  # solo focus → persona voice
 
-    # Add b → swarm. a is now non-focus, b is focus.
+    # Even when batching with two sessions, intermediates from the
+    # current speaker keep the persona voice (auto-pick is for non-
+    # focus / pierces only).
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
     db = r.classify(
-        kind="tool_pre", tag="tool_bash_grep", session_id="b",
+        kind="intermediate", tag="intermediate_short", session_id="b",
         auto_voices=True,
     )
-    assert db.voice_override is None  # focus → persona voice still
+    assert db.voice_override is None
 
 
 def test_manual_map_beats_auto_voice():
@@ -289,6 +301,7 @@ def test_manual_map_beats_auto_voice():
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
 
     fail_a = r.classify(
         kind="tool_post", tag="tool_post_failure", session_id="a",
@@ -336,14 +349,15 @@ def test_list_active_for_menu():
     assert names["web"]["pinned"] is False
 
 
-def test_swarm_single_voice_mode_prefixes_focus_agent():
-    """auto_voices off (the "One voice" mode): the focused agent's own
-    narration gets an "Agent <name>: " prefix, since the listener can't
-    tell agents apart by sound. With auto_voices on, no focus prefix.
-    Uses intermediate prose since tool events batch in swarm now."""
+def test_single_voice_mode_prefixes_focus_agent_when_batching():
+    """auto_voices off (the "One voice" mode): under batching, the
+    focused agent's own narration gets an "Agent <name>: " prefix
+    since the listener can't tell agents apart by sound. With
+    auto_voices on, no focus prefix."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
     d = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
     assert d.action == "speak"
     assert d.label_prefix.startswith("Agent web")
@@ -377,13 +391,13 @@ def test_single_voice_mode_skips_prefix_when_manual_voice_set():
 
 
 def test_single_voice_prefix_only_on_speaker_change():
-    """One-voice mode: the agent name is spoken only when the speaker
-    changes — not on every consecutive line from the agent you're
-    actively driving. Tested on intermediates since tool events now
-    batch in swarm."""
+    """One-voice mode under batching: the agent name is spoken only
+    when the speaker changes, not on every consecutive line from the
+    agent you're actively driving."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
     d1 = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
     assert d1.label_prefix.startswith("Agent web")  # first line → announce
     d2 = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
@@ -395,105 +409,53 @@ def test_single_voice_prefix_only_on_speaker_change():
     assert d4.label_prefix == ""  # same speaker again → silent
 
 
-def test_parallel_subagents_in_one_session_trigger_swarm():
-    """One CC session that fans out via the Agent tool sees all
-    subagents share its session_id, so naive session counting would
-    miss the concurrency. Tracking note_subagent_start brings them
-    into the swarm path even though only one top-level session is
-    active."""
+def test_high_event_rate_triggers_batching():
+    """A single session that's firing fast enough to overrun the
+    speech channel trips batching even with no other agents in play.
+    Catches the case of one CC session fanning out via the Agent
+    tool — those subagents share the parent session_id at the hook
+    layer, so we can only see them via the rate."""
     r = _new_router()
-    r.note_event("solo", cwd="/x/api")
-    # Single session, no subagents → solo, speak.
-    d = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
-    assert d.action == "speak"
-
-    # Same session fans out two Agent invocations → swarm-equivalent.
-    r.note_subagent_start("solo")
-    r.note_subagent_start("solo")
-    assert r.subagent_count("solo") == 2
-
-    d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
-    assert d2.action == "defer_to_digest"
-
-    # Finals from a session in subagent-swarm still speak with label.
-    d3 = r.classify(kind="final", tag="final_short", session_id="solo")
-    assert d3.action == "speak"
-
-
-def test_subagent_starts_age_out():
-    """Subagents that started a long time ago shouldn't keep a session
-    in swarm mode forever — entries expire from the rolling window."""
-    r = _new_router()
-    r.note_event("a")
-    r.note_subagent_start("a")
-    r.note_subagent_start("a")
-    # Backdate both starts past the tracking window.
-    expired = time.time() - multi_agent.SUBAGENT_TRACK_WINDOW_S - 10
-    r._sessions["a"].subagent_starts = [expired, expired]
-    assert r.subagent_count("a") == 0
-
-
-def test_high_event_rate_triggers_swarm_in_one_session():
-    """A single session that's firing faster than a sequential agent
-    plausibly could — the rate-based fallback signal for parallel
-    fan-out we can't see from explicit Agent-tool events."""
-    r = _new_router()
-    # Below threshold → solo.
+    # Below threshold → speak live.
     for _ in range(multi_agent.EVENT_RATE_THRESHOLD - 1):
         r.note_event("solo", cwd="/x/api")
     d = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
     assert d.action == "speak"
 
-    # Push the rolling window past threshold.
+    # Push past threshold → batch.
     for _ in range(3):
         r.note_event("solo", cwd="/x/api")
-    assert r.any_high_event_rate() is True
+    assert r.is_batching() is True
     d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
     assert d2.action == "defer_to_digest"
 
 
-def test_peak_subagent_count_across_sessions():
-    """peak_subagent_count returns the max parallel subagents on any
-    single session. Daemon uses it to flip digest cadence."""
+def test_event_rate_window_expires():
+    """The rolling window drops old timestamps so a long-ago burst
+    doesn't keep the router in batching mode."""
     r = _new_router()
-    r.note_event("a")
-    r.note_event("b")
-    r.note_subagent_start("a")
-    r.note_subagent_start("b")
-    r.note_subagent_start("b")
-    assert r.peak_subagent_count() == 2
+    _trip_batching(r)
+    assert r.is_batching() is True
+    expired = time.time() - multi_agent.EVENT_RATE_WINDOW_S - 1
+    r._event_times = [expired for _ in r._event_times]
+    assert r.is_batching() is False
 
 
-def test_active_count_tracks_recent_sessions():
-    """The daemon uses this to flip its digest cadence between fast
-    (swarm) and slow (solo)."""
-    r = _new_router()
-    assert r.active_count() == 0
-    r.note_event("a")
-    assert r.active_count() == 1
-    r.note_event("b")
-    assert r.active_count() == 2
-
-    # Backdate b past the active window — drops out of count.
-    r._sessions["b"].last_event = time.time() - multi_agent.SESSION_ACTIVE_S - 5
-    assert r.active_count() == 1
-
-
-def test_swarm_finals_speak_with_agent_label():
+def test_batching_finals_speak_with_agent_label():
     """Finals carry the agent's actual answer — flattening them into
     the digest's tag-count summary would lose the content. They speak
-    instead, with a label so the listener can tell which agent
-    finished. The speech queue serializes them so two finals from two
-    agents queue back-to-back without overlapping audio."""
+    instead with the speaker-change label so the listener can tell
+    which agent finished. Tool events still batch."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    _trip_batching(r, ("a", "b"))
 
-    final_a = r.classify(kind="final", tag="final_short", session_id="a")
+    final_a = r.classify(kind="final", tag="final_short", session_id="a", auto_voices=False)
     assert final_a.action == "speak"
     assert "api" in final_a.label_prefix
 
-    intermediate_b = r.classify(kind="intermediate", tag="intermediate_short", session_id="b")
+    intermediate_b = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
     assert intermediate_b.action == "speak"
     assert "web" in intermediate_b.label_prefix
 

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -2,9 +2,10 @@
 
 Three scenarios drive the design:
   - Solo: one CC instance, today's UX, everything plays.
-  - Swarm: 2+ instances active concurrently, naive narration is
-    incoherent. Most-recently-active narrates; others' routine
-    events drop or defer; failures/questions pierce with a label.
+  - Swarm: 2+ instances active concurrently. Every non-pierce event
+    batches into the digest pile; the daemon's adaptive digest timer
+    drains it as one combined line per window. Failures/questions
+    pierce with an agent label so urgent events still cut through.
   - Pinned: user explicitly chose one to follow. Only that session
     plays unconditionally; others pierce on critical only.
 """
@@ -31,27 +32,29 @@ def test_solo_mode_speaks_everything():
     assert r.mode() == multi_agent.Mode.SOLO
 
 
-def test_swarm_focus_speaks_others_defer():
-    """Two active sessions: most-recently-active gets routine
-    narration; the other defers to digest."""
+def test_swarm_defers_all_non_pierce_events():
+    """Two active sessions: every routine event defers to the digest
+    regardless of who fired most recently. The old "most-recently-
+    active speaks" behaviour caused two busy agents to trade speakers
+    on every event and step on each other."""
     r = _new_router()
     r.note_event("a", cwd="/Users/x/projects/api")
     r.note_event("b", cwd="/Users/x/projects/web")
-    # b fired more recently — it's the focus.
 
     assert r.mode() == multi_agent.Mode.SWARM
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "speak"
     a_decision = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a")
+    b_decision = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b")
     assert a_decision.action == "defer_to_digest"
+    assert b_decision.action == "defer_to_digest"
 
 
 def test_swarm_critical_pierces_with_label():
-    """Failures + questions from non-focus sessions still narrate,
-    prefixed with the agent label."""
+    """Failures + questions from any session in swarm still narrate,
+    prefixed with the agent label so urgent events cut through the
+    batched digest."""
     r = _new_router()
     r.note_event("a", cwd="/Users/x/projects/api")
     r.note_event("b", cwd="/Users/x/projects/web")
-    # b is focus.
 
     fail_a = r.classify(kind="tool_post", tag="tool_post_failure", session_id="a")
     assert fail_a.action == "speak"
@@ -62,19 +65,20 @@ def test_swarm_critical_pierces_with_label():
     assert "api" in q_a.label_prefix
 
 
-def test_focus_shifts_with_most_recent_activity():
-    """When a different session fires later, it becomes the focus."""
+def test_swarm_does_not_flip_focus_on_event_burst():
+    """Regression guard: a tight burst of alternating events from two
+    agents used to flip the live speaker on every event, which sounded
+    like two voices on top of each other. Now both stay batched."""
     r = _new_router()
     r.note_event("a")
     time.sleep(0.01)
     r.note_event("b")
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "speak"
+    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
     assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
 
-    # Now a fires — focus shifts back to a.
     time.sleep(0.01)
     r.note_event("a")
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "speak"
+    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
     assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
 
 
@@ -150,20 +154,21 @@ def test_digest_collection_drains_pending():
 
 def test_agent_voices_override_on_speak_decision():
     """When agent_voices maps a session's repo to a voice id, a speak
-    decision returns it as voice_override. b is the focus (most
-    recently active) so its event speaks; we expect the override."""
+    decision returns it as voice_override. Pinned mode is the natural
+    "this one speaks" path now that swarm batches everything."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    r.pin("a")
 
     voices = {"api": "voice_id_api", "web": "voice_id_web"}
-    db = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", agent_voices=voices)
-    assert db.action == "speak"
-    assert db.voice_override == "voice_id_web"
+    da = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a", agent_voices=voices)
+    assert da.action == "speak"
+    assert da.voice_override == "voice_id_api"
 
     # Without the map: None.
-    db_no_map = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b")
-    assert db_no_map.voice_override is None
+    da_no_map = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a")
+    assert da_no_map.voice_override is None
 
 
 def test_agent_voices_override_on_pierce_too():
@@ -334,14 +339,15 @@ def test_list_active_for_menu():
 def test_swarm_single_voice_mode_prefixes_focus_agent():
     """auto_voices off (the "One voice" mode): the focused agent's own
     narration gets an "Agent <name>: " prefix, since the listener can't
-    tell agents apart by sound. With auto_voices on, no focus prefix."""
+    tell agents apart by sound. With auto_voices on, no focus prefix.
+    Uses intermediate prose since tool events batch in swarm now."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
-    r.note_event("b", cwd="/x/web")  # most recent → focus
-    d = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=False)
+    r.note_event("b", cwd="/x/web")
+    d = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
     assert d.action == "speak"
     assert d.label_prefix.startswith("Agent web")
-    d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=True)
+    d2 = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=True)
     assert d2.action == "speak"
     assert d2.label_prefix == ""
 
@@ -356,12 +362,13 @@ def test_solo_never_prefixes_even_in_single_voice_mode():
 
 def test_single_voice_mode_skips_prefix_when_manual_voice_set():
     """A manually-mapped voice carries the agent's identity — no prefix
-    needed even in single-voice mode."""
+    needed even in single-voice mode. Uses intermediate prose since tool
+    events batch in swarm now."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
-    r.note_event("b", cwd="/x/web")  # focus
+    r.note_event("b", cwd="/x/web")
     d = r.classify(
-        kind="tool_pre", tag="tool_bash_grep", session_id="b",
+        kind="intermediate", tag="intermediate_short", session_id="b",
         agent_voices={"web": "voice_xyz"}, auto_voices=False,
     )
     assert d.action == "speak"
@@ -372,16 +379,73 @@ def test_single_voice_mode_skips_prefix_when_manual_voice_set():
 def test_single_voice_prefix_only_on_speaker_change():
     """One-voice mode: the agent name is spoken only when the speaker
     changes — not on every consecutive line from the agent you're
-    actively driving."""
+    actively driving. Tested on intermediates since tool events now
+    batch in swarm."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
-    r.note_event("b", cwd="/x/web")  # b is focus (most recent)
-    d1 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=False)
+    r.note_event("b", cwd="/x/web")
+    d1 = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
     assert d1.label_prefix.startswith("Agent web")  # first line → announce
-    d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=False)
+    d2 = r.classify(kind="intermediate", tag="intermediate_short", session_id="b", auto_voices=False)
     assert d2.label_prefix == ""  # same speaker → silent
-    r.note_event("a")  # focus shifts
-    d3 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a", auto_voices=False)
+    r.note_event("a")
+    d3 = r.classify(kind="intermediate", tag="intermediate_short", session_id="a", auto_voices=False)
     assert d3.label_prefix.startswith("Agent api")  # speaker changed → announce
-    d4 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a", auto_voices=False)
+    d4 = r.classify(kind="intermediate", tag="intermediate_short", session_id="a", auto_voices=False)
     assert d4.label_prefix == ""  # same speaker again → silent
+
+
+def test_active_count_tracks_recent_sessions():
+    """The daemon uses this to flip its digest cadence between fast
+    (swarm) and slow (solo)."""
+    r = _new_router()
+    assert r.active_count() == 0
+    r.note_event("a")
+    assert r.active_count() == 1
+    r.note_event("b")
+    assert r.active_count() == 2
+
+    # Backdate b past the active window — drops out of count.
+    r._sessions["b"].last_event = time.time() - multi_agent.SESSION_ACTIVE_S - 5
+    assert r.active_count() == 1
+
+
+def test_swarm_finals_speak_with_agent_label():
+    """Finals carry the agent's actual answer — flattening them into
+    the digest's tag-count summary would lose the content. They speak
+    instead, with a label so the listener can tell which agent
+    finished. The speech queue serializes them so two finals from two
+    agents queue back-to-back without overlapping audio."""
+    r = _new_router()
+    r.note_event("a", cwd="/x/api")
+    r.note_event("b", cwd="/x/web")
+
+    final_a = r.classify(kind="final", tag="final_short", session_id="a")
+    assert final_a.action == "speak"
+    assert "api" in final_a.label_prefix
+
+    intermediate_b = r.classify(kind="intermediate", tag="intermediate_short", session_id="b")
+    assert intermediate_b.action == "speak"
+    assert "web" in intermediate_b.label_prefix
+
+    # Tool events still batch.
+    tool_a = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a")
+    assert tool_a.action == "defer_to_digest"
+
+
+def test_format_digest_drops_preface_when_swarm_active():
+    """In swarm mode the digest fires every few seconds as the primary
+    narration channel; the "Background update." preface would sound
+    like a stuck record. Drop it when swarm_active=True."""
+    r = _new_router()
+    r.note_event("a", cwd="/x/api")
+    r.add_to_digest("a", "tool_pre", "tool_edit", "Editing x.")
+
+    quiet = r.format_digest(swarm_active=False)
+    assert quiet is not None and quiet.startswith("Background update.")
+
+    r.add_to_digest("a", "tool_pre", "tool_edit", "Editing y.")
+    busy = r.format_digest(swarm_active=True)
+    assert busy is not None
+    assert not busy.startswith("Background update.")
+    assert "Api" in busy

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -395,6 +395,75 @@ def test_single_voice_prefix_only_on_speaker_change():
     assert d4.label_prefix == ""  # same speaker again → silent
 
 
+def test_parallel_subagents_in_one_session_trigger_swarm():
+    """One CC session that fans out via the Agent tool sees all
+    subagents share its session_id, so naive session counting would
+    miss the concurrency. Tracking note_subagent_start brings them
+    into the swarm path even though only one top-level session is
+    active."""
+    r = _new_router()
+    r.note_event("solo", cwd="/x/api")
+    # Single session, no subagents → solo, speak.
+    d = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
+    assert d.action == "speak"
+
+    # Same session fans out two Agent invocations → swarm-equivalent.
+    r.note_subagent_start("solo")
+    r.note_subagent_start("solo")
+    assert r.subagent_count("solo") == 2
+
+    d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
+    assert d2.action == "defer_to_digest"
+
+    # Finals from a session in subagent-swarm still speak with label.
+    d3 = r.classify(kind="final", tag="final_short", session_id="solo")
+    assert d3.action == "speak"
+
+
+def test_subagent_starts_age_out():
+    """Subagents that started a long time ago shouldn't keep a session
+    in swarm mode forever — entries expire from the rolling window."""
+    r = _new_router()
+    r.note_event("a")
+    r.note_subagent_start("a")
+    r.note_subagent_start("a")
+    # Backdate both starts past the tracking window.
+    expired = time.time() - multi_agent.SUBAGENT_TRACK_WINDOW_S - 10
+    r._sessions["a"].subagent_starts = [expired, expired]
+    assert r.subagent_count("a") == 0
+
+
+def test_high_event_rate_triggers_swarm_in_one_session():
+    """A single session that's firing faster than a sequential agent
+    plausibly could — the rate-based fallback signal for parallel
+    fan-out we can't see from explicit Agent-tool events."""
+    r = _new_router()
+    # Below threshold → solo.
+    for _ in range(multi_agent.EVENT_RATE_THRESHOLD - 1):
+        r.note_event("solo", cwd="/x/api")
+    d = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
+    assert d.action == "speak"
+
+    # Push the rolling window past threshold.
+    for _ in range(3):
+        r.note_event("solo", cwd="/x/api")
+    assert r.any_high_event_rate() is True
+    d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="solo")
+    assert d2.action == "defer_to_digest"
+
+
+def test_peak_subagent_count_across_sessions():
+    """peak_subagent_count returns the max parallel subagents on any
+    single session. Daemon uses it to flip digest cadence."""
+    r = _new_router()
+    r.note_event("a")
+    r.note_event("b")
+    r.note_subagent_start("a")
+    r.note_subagent_start("b")
+    r.note_subagent_start("b")
+    assert r.peak_subagent_count() == 2
+
+
 def test_active_count_tracks_recent_sessions():
     """The daemon uses this to flip its digest cadence between fast
     (swarm) and slow (solo)."""


### PR DESCRIPTION
## Summary

- One rule: speech is serial (~one utterance per second), so when events arrive faster than we can speak them, batch. Replaces the old SOLO/SWARM session-count heuristic that flipped focus on every event and let two busy agents step on each other.
- Inter-session by construction: a single global rolling window counts events across all sessions, so two CC instances each at moderate pace combine into one signal and trip together. Also catches one CC session fanning out via the Agent tool — those subagents share the parent session_id at the hook layer, so session counting alone misses them.
- Defaults: six events in three seconds trips batching. While batching, routine tool events defer to the digest pile (drained every five seconds with per-session labels preserved); finals + intermediates speak with the speaker-change label so prose isn't lost; failures + questions pierce with an `Agent <name>:` prefix.
- Net diff: minus a hundred and forty-two lines across `heard/` + `tests/` after the simplification pass. The router collapses to one `is_batching()` signal feeding three call sites.

## Test plan

- [x] `pytest -q` (352 passed, 1 skipped)
- [x] `ruff check heard/ tests/`
- [ ] Hot-patch into `/Applications/Heard.app` and confirm:
  - Two CC instances in two terminals both narrating → digest fires every ~five seconds with per-session labels, no audio overlap.
  - One CC session that fans out via the Agent tool → event rate trips batching even though only one session_id is live.
  - Single busy agent doing a tool-call burst → brief batching window, returns to live narration when the burst ends.
  - Failures / questions still cut through with the agent label during batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)