### PR TITLE
feat(multi-agent): per-channel scheduler with idle and backpressure flush

### DIFF
--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -205,28 +205,39 @@ class Daemon:
         )
 
     def _start_digest_timer(self) -> None:
-        """Periodic background-agent digest. Drains the router's
-        deferred events on every tick, formats a one-line summary,
-        and enqueues it as a synthetic intermediate event. No-op when
-        nothing's accumulated (solo-mode, idle, or feature off)."""
+        """Per-channel scheduler. Ticks every second; for each session
+        whose pending pile is either idle (no events for a couple of
+        seconds — natural turn boundary) or has hit the backpressure
+        cap (runaway busy agent), drain just that session's pile and
+        speak it as one summarized utterance attributed to the agent.
+
+        Single-channel scenarios bypass this entirely because the
+        router only routes events to defer when two or more sessions
+        are active; with one session, classify() returns speak and
+        the live path takes over."""
 
         def _tick() -> None:
             while True:
-                interval = float(self.cfg.get("multi_agent_digest_interval_s") or 60)
-                time.sleep(max(15.0, interval))
+                time.sleep(1.0)
                 if not self.cfg.get("multi_agent_digest_enabled", True):
-                    # Drop accumulated events silently — feature off.
+                    # Feature off — drop everything that piled up.
                     self.router.collect_digest()
                     continue
-                drained = self.router.collect_digest()
-                summary = self.router.format_digest(drained)
-                if not summary:
-                    continue
-                _log("digest_emit", chars=len(summary), sessions=len(drained))
-                # Use a "digest" session id so the router's own
-                # classify() doesn't try to suppress this. Voice falls
-                # through to the active persona/cfg.
-                self._start_speech(summary, cfg=self.cfg, persona=self.persona, session_id="__digest__")
+                for session_id in self.router.sessions_ready_to_flush():
+                    summary = self.router.drain_session_summary(session_id)
+                    if not summary:
+                        continue
+                    _log(
+                        "channel_flush",
+                        session=session_id,
+                        chars=len(summary),
+                    )
+                    self._start_speech(
+                        summary,
+                        cfg=self.cfg,
+                        persona=self.persona,
+                        session_id=session_id,
+                    )
 
         threading.Thread(target=_tick, daemon=True).start()
 

--- a/heard/multi_agent.py
+++ b/heard/multi_agent.py
@@ -63,11 +63,20 @@ def _auto_voice_for(repo_name: str) -> str:
     digest = hashlib.sha1(repo_name.encode("utf-8")).hexdigest()
     return _AUTO_VOICE_POOL[int(digest, 16) % len(_AUTO_VOICE_POOL)]
 
-# How long after the last event a session counts as "active". Used
-# both for the SOLO/SWARM mode decision and for the menu's active-
-# sessions list. 30 s is roughly "I just ran a thing, the agent's
-# still cooking".
-SESSION_ACTIVE_S = 30.0
+# How long after the last event a session counts as "active" for the
+# SOLO/SWARM decision. 180 s captures bursty rotation: if you've
+# touched an agent in the last few minutes it still counts as
+# running, so opening a second Claude Code anywhere flips the system
+# into the multi-channel scheduler implicitly.
+SESSION_ACTIVE_S = 180.0
+
+# Per-channel flush rules used by the daemon's scheduler when the
+# router is in multi-channel mode. A channel flushes when its pending
+# pile has been quiet for IDLE_S (natural turn boundary) OR its
+# pending count hits MAX_PENDING (backpressure cap so a runaway
+# busy agent doesn't hold its summary hostage).
+CHANNEL_IDLE_FLUSH_S = 2.0
+CHANNEL_MAX_PENDING = 5
 
 # Show a session in active_sessions() for this long after its last
 # event, even if it's no longer "active" for mode purposes. Lets the
@@ -227,6 +236,25 @@ class MultiAgentRouter:
                 return Mode.PINNED
             return Mode.SWARM if len(self._active_locked(time.time())) >= 2 else Mode.SOLO
 
+    def sessions_ready_to_flush(self) -> list[str]:
+        """Return the session_ids whose pending piles should be drained
+        right now. Sorted longest-pile first so the daemon's scheduler
+        handles the worst backlog when ties collide. A pile is ready
+        when it's been idle CHANNEL_IDLE_FLUSH_S seconds (natural turn
+        boundary) OR has hit CHANNEL_MAX_PENDING (backpressure)."""
+        with self._lock:
+            now = time.time()
+            ready: list[tuple[int, str]] = []
+            for sid, info in self._sessions.items():
+                pending = len(info.pending_digest)
+                if pending == 0:
+                    continue
+                idle_for = now - info.last_event
+                if idle_for >= CHANNEL_IDLE_FLUSH_S or pending >= CHANNEL_MAX_PENDING:
+                    ready.append((pending, sid))
+            ready.sort(key=lambda t: -t[0])
+            return [sid for _, sid in ready]
+
     # --- routing -----------------------------------------------------------
 
     def classify(
@@ -275,24 +303,12 @@ class MultiAgentRouter:
                     session_id, RoutingDecision(action="speak", voice_override=voice)
                 )
 
-            # Swarm: >=2 active. Most-recently-active wins; others
-            # pierce only on critical tags, otherwise digest-defer.
-            most_recent = max(active, key=lambda s: (s.last_event, s.event_seq))
-            is_focus = session_id == most_recent.session_id
-            if is_focus:
-                voice = self._voice_for_locked(
-                    session_id, agent_voices, auto_voices, is_focus=True
-                )
-                return self._speaking_locked(
-                    session_id,
-                    RoutingDecision(
-                        action="speak",
-                        voice_override=voice,
-                        label_prefix=self._focus_label_prefix_locked(
-                            session_id, agent_voices, auto_voices, now
-                        ),
-                    ),
-                )
+            # Multi-channel: every non-pierce event lands in its own
+            # session's pending pile. The daemon's per-session scheduler
+            # drains each channel as one summarized utterance when the
+            # pile goes quiet (CHANNEL_IDLE_FLUSH_S) or hits the
+            # backpressure cap (CHANNEL_MAX_PENDING). Nothing is dropped;
+            # the user hears each agent's batched catch-up in turn.
             if tag in _PIERCE_TAGS:
                 voice = self._voice_for_locked(
                     session_id, agent_voices, auto_voices, is_focus=False

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -31,18 +31,18 @@ def test_solo_mode_speaks_everything():
     assert r.mode() == multi_agent.Mode.SOLO
 
 
-def test_swarm_focus_speaks_others_defer():
-    """Two active sessions: most-recently-active gets routine
-    narration; the other defers to digest."""
+def test_swarm_all_non_pierce_events_defer():
+    """Multi-channel mode: every routine event lands in its own
+    session's pending pile. There's no live "focus speaker" — the
+    daemon's per-session scheduler drains each channel separately
+    once idle or backpressured."""
     r = _new_router()
     r.note_event("a", cwd="/Users/x/projects/api")
     r.note_event("b", cwd="/Users/x/projects/web")
-    # b fired more recently — it's the focus.
 
     assert r.mode() == multi_agent.Mode.SWARM
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "speak"
-    a_decision = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a")
-    assert a_decision.action == "defer_to_digest"
+    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
+    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
 
 
 def test_swarm_critical_pierces_with_label():
@@ -62,20 +62,48 @@ def test_swarm_critical_pierces_with_label():
     assert "api" in q_a.label_prefix
 
 
-def test_focus_shifts_with_most_recent_activity():
-    """When a different session fires later, it becomes the focus."""
+def test_sessions_ready_to_flush_on_idle():
+    """A pending pile that's been quiet for CHANNEL_IDLE_FLUSH_S
+    becomes ready to flush — natural turn boundary."""
     r = _new_router()
-    r.note_event("a")
-    time.sleep(0.01)
-    r.note_event("b")
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "speak"
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "defer_to_digest"
+    r.note_event("a", cwd="/x/api")
+    r.note_event("b", cwd="/x/web")
+    r.add_to_digest("a", "tool_pre", "tool_edit", "Editing x.")
+    # Both fresh — neither idle yet.
+    assert r.sessions_ready_to_flush() == []
 
-    # Now a fires — focus shifts back to a.
-    time.sleep(0.01)
-    r.note_event("a")
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a").action == "speak"
-    assert r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b").action == "defer_to_digest"
+    # Backdate a past the idle window.
+    r._sessions["a"].last_event = time.time() - multi_agent.CHANNEL_IDLE_FLUSH_S - 0.5
+    assert r.sessions_ready_to_flush() == ["a"]
+
+
+def test_sessions_ready_to_flush_on_backpressure():
+    """A pending pile that hits CHANNEL_MAX_PENDING flushes even if
+    fresh — a runaway busy agent shouldn't hold its summary hostage."""
+    r = _new_router()
+    r.note_event("a", cwd="/x/api")
+    for _ in range(multi_agent.CHANNEL_MAX_PENDING):
+        r.add_to_digest("a", "tool_pre", "tool_edit", "Editing x.")
+    # Even though a is fresh, backpressure ready.
+    assert "a" in r.sessions_ready_to_flush()
+
+
+def test_sessions_ready_to_flush_longest_first():
+    """When several channels are due at once, longest pile wins so
+    the worst backlog gets drained first."""
+    r = _new_router()
+    r.note_event("a", cwd="/x/api")
+    r.note_event("b", cwd="/x/web")
+    for _ in range(3):
+        r.add_to_digest("a", "tool_pre", "tool_edit", "Editing x.")
+    for _ in range(5):
+        r.add_to_digest("b", "tool_pre", "tool_edit", "Editing y.")
+    # Force both idle.
+    old = time.time() - multi_agent.CHANNEL_IDLE_FLUSH_S - 0.5
+    r._sessions["a"].last_event = old
+    r._sessions["b"].last_event = old
+    ready = r.sessions_ready_to_flush()
+    assert ready == ["b", "a"]
 
 
 def test_pinned_session_always_speaks_others_drop():
@@ -150,20 +178,22 @@ def test_digest_collection_drains_pending():
 
 def test_agent_voices_override_on_speak_decision():
     """When agent_voices maps a session's repo to a voice id, a speak
-    decision returns it as voice_override. b is the focus (most
-    recently active) so its event speaks; we expect the override."""
+    decision returns it as voice_override. Pinned mode is the
+    canonical "this one speaks" path now that multi-channel always
+    defers routine events."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
     r.note_event("b", cwd="/x/web")
+    r.pin("a")
 
     voices = {"api": "voice_id_api", "web": "voice_id_web"}
-    db = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", agent_voices=voices)
-    assert db.action == "speak"
-    assert db.voice_override == "voice_id_web"
+    da = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a", agent_voices=voices)
+    assert da.action == "speak"
+    assert da.voice_override == "voice_id_api"
 
     # Without the map: None.
-    db_no_map = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b")
-    assert db_no_map.voice_override is None
+    da_no_map = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a")
+    assert da_no_map.voice_override is None
 
 
 def test_agent_voices_override_on_pierce_too():
@@ -331,13 +361,15 @@ def test_list_active_for_menu():
     assert names["web"]["pinned"] is False
 
 
-def test_swarm_single_voice_mode_prefixes_focus_agent():
-    """auto_voices off (the "One voice" mode): the focused agent's own
-    narration gets an "Agent <name>: " prefix, since the listener can't
-    tell agents apart by sound. With auto_voices on, no focus prefix."""
+def test_pinned_single_voice_mode_prefixes_pinned_agent():
+    """auto_voices off (the "One voice" mode): the pinned agent's own
+    narration gets an "Agent <name>: " prefix when another channel
+    is active in the background, since the listener can't tell agents
+    apart by sound. With auto_voices on, no prefix."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
-    r.note_event("b", cwd="/x/web")  # most recent → focus
+    r.note_event("b", cwd="/x/web")
+    r.pin("b")
     d = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=False)
     assert d.action == "speak"
     assert d.label_prefix.startswith("Agent web")
@@ -359,7 +391,8 @@ def test_single_voice_mode_skips_prefix_when_manual_voice_set():
     needed even in single-voice mode."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
-    r.note_event("b", cwd="/x/web")  # focus
+    r.note_event("b", cwd="/x/web")
+    r.pin("b")
     d = r.classify(
         kind="tool_pre", tag="tool_bash_grep", session_id="b",
         agent_voices={"web": "voice_xyz"}, auto_voices=False,
@@ -370,18 +403,19 @@ def test_single_voice_mode_skips_prefix_when_manual_voice_set():
 
 
 def test_single_voice_prefix_only_on_speaker_change():
-    """One-voice mode: the agent name is spoken only when the speaker
-    changes — not on every consecutive line from the agent you're
-    actively driving."""
+    """One-voice mode: the agent name announces once on speaker change,
+    then stays silent for consecutive lines from that agent. Tested
+    against the pinned + cross-pierce path since live speakers in
+    multi-channel mode are pierces only now."""
     r = _new_router()
     r.note_event("a", cwd="/x/api")
-    r.note_event("b", cwd="/x/web")  # b is focus (most recent)
+    r.note_event("b", cwd="/x/web")
+    r.pin("b")
+    # b speaks first with the prefix because it's the first speaker.
     d1 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=False)
-    assert d1.label_prefix.startswith("Agent web")  # first line → announce
+    assert d1.label_prefix.startswith("Agent web")
     d2 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="b", auto_voices=False)
     assert d2.label_prefix == ""  # same speaker → silent
-    r.note_event("a")  # focus shifts
-    d3 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a", auto_voices=False)
-    assert d3.label_prefix.startswith("Agent api")  # speaker changed → announce
-    d4 = r.classify(kind="tool_pre", tag="tool_bash_grep", session_id="a", auto_voices=False)
-    assert d4.label_prefix == ""  # same speaker again → silent
+    # a pierces with a failure — speaker change announces.
+    d3 = r.classify(kind="tool_post", tag="tool_post_failure", session_id="a", auto_voices=False)
+    assert "api" in d3.label_prefix


### PR DESCRIPTION
## Summary

- Replaces the "most recently active speaks" swarm heuristic. That flipped focus on every event when two agents were busy, so the listener heard them stepping on each other. Today's main avoids that by destructively dropping older queued items via `queue_drop_other_session` — coherent but lossy: you never hear the agents you're not currently driving.
- New model: when two or more sessions are active (last 3 minutes), every non-pierce event lands in its own session's pending pile. A per-session scheduler ticks every second and drains any channel that's idle for 2 seconds (natural turn boundary) OR has hit 5 pending items (backpressure cap). Longest pile wins ties.
- Each per-channel flush speaks as one utterance attributed to that session, so the speaker-change label naturally tags who said what and the speech queue serializes channels. No two voices overlap, and the background agents' summaries arrive instead of vanishing.
- Single-channel scenarios bypass the scheduler entirely — one CC session firing events still speaks live, no two-second batching latency.
- Pierces (failures, questions) still cut through immediately with an `Agent <name>:` label, regardless of mode.

Draft because the per-channel drain still uses the existing tag-count digest format (`Api: 3 edits, a test`). That works but isn't very narrative. Want to validate the structure works end-to-end with real parallel agents before swapping in a Haiku-summarized version of the actual prose.

## Test plan

- [x] `pytest -q` (354 passed, 1 skipped)
- [x] `ruff check heard/ tests/`
- [ ] Two CC instances in two terminals working concurrently — each agent's bursts should drain as a single attributed summary about two seconds after it goes quiet.
- [ ] One CC session by itself — narration plays live with no extra latency (scheduler should not engage).
- [ ] Failure / question events during multi-channel — pierce immediately with the agent label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)