### PR TITLE
fix(narration): summarise AskUserQuestion instead of late prose

### DIFF
--- a/heard/client.py
+++ b/heard/client.py
@@ -528,6 +528,10 @@ def handle_cc_pre_tool(data: dict) -> None:
     transcript = data.get("transcript_path")
     spoke_text = 0
     if transcript:
+        # Match Stop's flush wait — Claude Code may not have flushed the
+        # assistant-prose line to the transcript yet when this hook fires,
+        # so reading immediately misses prose written right before the tool.
+        time.sleep(cfg["flush_delay_ms"] / 1000.0)
         spoke_text = _speak_unspoken_texts(transcript, session, cfg, finalize=False)
 
     if spoke_text > 0:
@@ -611,6 +615,10 @@ def handle_codex_pre_tool(data: dict) -> None:
     transcript = data.get("transcript_path")
     spoke_text = 0
     if transcript:
+        # Match Stop's flush wait — Claude Code may not have flushed the
+        # assistant-prose line to the transcript yet when this hook fires,
+        # so reading immediately misses prose written right before the tool.
+        time.sleep(cfg["flush_delay_ms"] / 1000.0)
         spoke_text = _speak_unspoken_texts(transcript, session, cfg, finalize=False)
 
     if spoke_text > 0:

--- a/heard/client.py
+++ b/heard/client.py
@@ -440,6 +440,18 @@ def _session_from_data(data: dict) -> dict:
 # --- Claude Code event handlers ---------------------------------------------
 
 
+def _mark_transcript_prose_spoken(transcript_path: str, sid: str) -> None:
+    """Advance the offset and mark all pending assistant prose as spoken
+    without sending it. Used to suppress narration we know would land
+    too late to be useful."""
+    start = spoken.get_offset(sid)
+    fresh, end = extract_assistant_texts_from(transcript_path, start)
+    if end != start:
+        spoken.set_offset(sid, end)
+    for t in fresh:
+        spoken.mark_spoken(sid, t)
+
+
 def _speak_unspoken_texts(
     transcript_path: str,
     session: dict,
@@ -521,35 +533,17 @@ def handle_cc_pre_tool(data: dict) -> None:
     transcript = data.get("transcript_path")
     tool_name = data.get("tool_name") or ""
 
-    # AskUserQuestion races us. The hook is registered async, so CC shows
-    # the popup immediately while we're still sleeping for the flush; if
-    # the model wrote a long preface, ElevenLabs synth runs 0.3–6 s and
-    # the user has typically answered before audio plays. Stale prose
-    # arriving after the answer is worse than silence — and Stop would
-    # later re-narrate it if left unspoken. So mark pending prose as
-    # spoken without sending it, then forward the question itself via
-    # the tool_question template (Haiku summarises down to one sentence
-    # so synthesis stays short).
+    # AskUserQuestion's popup races our async hook — preface prose
+    # would land after the user answered. Mark it spoken (Stop won't
+    # replay) and narrate the question itself instead.
     if tool_name == "AskUserQuestion":
         if transcript:
             time.sleep(cfg["flush_delay_ms"] / 1000.0)
-            sid = session["id"]
-            start = spoken.get_offset(sid)
-            fresh, end = extract_assistant_texts_from(transcript, start)
-            if end != start:
-                spoken.set_offset(sid, end)
-            for t in fresh:
-                spoken.mark_spoken(sid, t)
+            _mark_transcript_prose_spoken(transcript, session["id"])
         if cfg.get("narrate_tools", True):
             ev = templates.pre_tool_event(tool_name, data.get("tool_input") or {})
             if ev is not None:
-                send_event(
-                    kind="tool_pre",
-                    neutral=ev.text,
-                    tag=ev.tag,
-                    ctx=ev.ctx,
-                    session=session,
-                )
+                send_event(kind="tool_pre", neutral=ev.text, tag=ev.tag, ctx=ev.ctx, session=session)
         return
 
     # First, surface any prose Claude wrote leading up to this tool call.

--- a/heard/client.py
+++ b/heard/client.py
@@ -518,6 +518,39 @@ def handle_cc_stop(data: dict) -> None:
 def handle_cc_pre_tool(data: dict) -> None:
     cfg = config.load()
     session = _session_from_data(data)
+    transcript = data.get("transcript_path")
+    tool_name = data.get("tool_name") or ""
+
+    # AskUserQuestion races us. The hook is registered async, so CC shows
+    # the popup immediately while we're still sleeping for the flush; if
+    # the model wrote a long preface, ElevenLabs synth runs 0.3–6 s and
+    # the user has typically answered before audio plays. Stale prose
+    # arriving after the answer is worse than silence — and Stop would
+    # later re-narrate it if left unspoken. So mark pending prose as
+    # spoken without sending it, then forward the question itself via
+    # the tool_question template (Haiku summarises down to one sentence
+    # so synthesis stays short).
+    if tool_name == "AskUserQuestion":
+        if transcript:
+            time.sleep(cfg["flush_delay_ms"] / 1000.0)
+            sid = session["id"]
+            start = spoken.get_offset(sid)
+            fresh, end = extract_assistant_texts_from(transcript, start)
+            if end != start:
+                spoken.set_offset(sid, end)
+            for t in fresh:
+                spoken.mark_spoken(sid, t)
+        if cfg.get("narrate_tools", True):
+            ev = templates.pre_tool_event(tool_name, data.get("tool_input") or {})
+            if ev is not None:
+                send_event(
+                    kind="tool_pre",
+                    neutral=ev.text,
+                    tag=ev.tag,
+                    ctx=ev.ctx,
+                    session=session,
+                )
+        return
 
     # First, surface any prose Claude wrote leading up to this tool call.
     # If we said something, the tool announcement would just be noise on
@@ -525,7 +558,6 @@ def handle_cc_pre_tool(data: dict) -> None:
     # fresh prose to suppress), we still enrich its ctx with the latest
     # transcript prose + the actual change content so persona Haiku can
     # produce a purposeful status line instead of a bare template verb.
-    transcript = data.get("transcript_path")
     spoke_text = 0
     if transcript:
         # Match Stop's flush wait — Claude Code may not have flushed the

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -644,6 +644,17 @@ def _build_user_message(
             "Write ONE sentence describing what just happened. PAST tense — "
             "the tool has run. Stay in character. No markdown."
         )
+    elif event_kind == "tool_pre" and tag == "tool_question":
+        # AskUserQuestion races the popup — we have a few hundred ms
+        # of synth budget before the user starts answering. Summarise
+        # the question to one short spoken sentence so audio lands
+        # while the popup is still on screen, instead of synthing the
+        # full question text verbatim (which can run several seconds).
+        lines.append(
+            "Summarise the question in ONE short sentence I will speak "
+            "aloud. Lead with 'Quick question:'. Stay in character. No "
+            "markdown. No options. Under 12 words."
+        )
     elif event_kind == "tool_pre" and recent_intent:
         # Status while a specific tool runs. Phrase, not a sentence —
         # these fire dozens of times per turn and every word costs

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -645,11 +645,6 @@ def _build_user_message(
             "the tool has run. Stay in character. No markdown."
         )
     elif event_kind == "tool_pre" and tag == "tool_question":
-        # AskUserQuestion races the popup — we have a few hundred ms
-        # of synth budget before the user starts answering. Summarise
-        # the question to one short spoken sentence so audio lands
-        # while the popup is still on screen, instead of synthing the
-        # full question text verbatim (which can run several seconds).
         lines.append(
             "Summarise the question in ONE short sentence I will speak "
             "aloud. Lead with 'Quick question:'. Stay in character. No "

--- a/heard/templates.py
+++ b/heard/templates.py
@@ -246,7 +246,15 @@ def pre_tool_event(tool_name: str, tool_input: dict[str, Any] | None) -> Narrati
         if questions:
             q = (questions[0].get("question") or "").strip()
             if q:
-                return Narration(tag="tool_question", text=q, ctx={"question": q})
+                # recent_intent flips Haiku eligibility on so the question
+                # gets summarised to one short sentence rather than synthed
+                # verbatim — keeps audio short enough to land while the
+                # popup is still on screen.
+                return Narration(
+                    tag="tool_question",
+                    text=q,
+                    ctx={"question": q, "recent_intent": q},
+                )
         return None
     if tn == "Skill":
         skill = (tool_input.get("skill") or "").strip()

--- a/heard/templates.py
+++ b/heard/templates.py
@@ -246,15 +246,9 @@ def pre_tool_event(tool_name: str, tool_input: dict[str, Any] | None) -> Narrati
         if questions:
             q = (questions[0].get("question") or "").strip()
             if q:
-                # recent_intent flips Haiku eligibility on so the question
-                # gets summarised to one short sentence rather than synthed
-                # verbatim — keeps audio short enough to land while the
-                # popup is still on screen.
-                return Narration(
-                    tag="tool_question",
-                    text=q,
-                    ctx={"question": q, "recent_intent": q},
-                )
+                # recent_intent flips Haiku on so the question gets
+                # summarised to one sentence instead of synthed verbatim.
+                return Narration(tag="tool_question", text=q, ctx={"question": q, "recent_intent": q})
         return None
     if tn == "Skill":
         skill = (tool_input.get("skill") or "").strip()

--- a/packaging/app_entry.py
+++ b/packaging/app_entry.py
@@ -28,8 +28,19 @@ try:
 except Exception:
     pass
 
+from heard import config as config_mod  # noqa: E402
 from heard import daemon as daemon_mod  # noqa: E402
 from heard.ui import HeardApp  # noqa: E402
+
+
+def _redirect_stdio_to_log() -> None:
+    # Bundle stdout/stderr default to /dev/null when the .app is
+    # launched by Finder/launchctl, which sinks the daemon thread's
+    # _log() lines. Point them at daemon.log so events stay greppable
+    # — matches what ensure_daemon's subprocess path already does.
+    log = open(config_mod.LOG_PATH, "a", encoding="utf-8", buffering=1)
+    sys.stdout = log
+    sys.stderr = log
 
 
 def _run_daemon() -> None:
@@ -46,5 +57,6 @@ def _run_daemon() -> None:
 
 
 if __name__ == "__main__":
+    _redirect_stdio_to_log()
     threading.Timer(1.0, _run_daemon).start()
     HeardApp().run()

--- a/tests/test_intermediate_text.py
+++ b/tests/test_intermediate_text.py
@@ -230,6 +230,60 @@ def test_no_duplicate_speech_across_sequential_pre_tool_calls(tmp_path, monkeypa
     assert len(intermediate) == 1
 
 
+def test_ask_user_question_suppresses_prose_and_marks_it_spoken(
+    tmp_path, monkeypatch
+):
+    """AskUserQuestion: the popup races our async hook, so any prose we
+    queue lands after the user has answered. Suppress the prose at
+    PreToolUse AND mark it spoken so the trailing Stop doesn't re-narrate
+    it. The popup itself carries the question."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            ("user", [{"type": "text", "text": "go"}]),
+            (
+                "assistant",
+                [{"type": "text", "text": "Quick clarifying question first."}],
+            ),
+            ("assistant", [{"type": "tool_use", "name": "AskUserQuestion"}]),
+        ],
+    )
+    sent: list[dict] = []
+    monkeypatch.setattr(client, "send_event", lambda **kw: sent.append(kw))
+    monkeypatch.setattr("heard.client.time.sleep", lambda _: None)
+
+    client.handle_cc_pre_tool(
+        {
+            "session_id": "session-Q",
+            "transcript_path": str(transcript),
+            "tool_name": "AskUserQuestion",
+            "tool_input": {
+                "questions": [
+                    {"question": "Which file?", "header": "f", "options": []}
+                ]
+            },
+        }
+    )
+
+    # Long preface suppressed; the question itself rides through with
+    # recent_intent set so persona Haiku will summarise it down to one
+    # short sentence rather than synthing the whole thing verbatim.
+    assert len(sent) == 1
+    assert sent[0]["kind"] == "tool_pre"
+    assert sent[0]["tag"] == "tool_question"
+    assert sent[0]["neutral"] == "Which file?"
+    assert sent[0]["ctx"].get("recent_intent") == "Which file?"
+
+    # Stop runs after the user answers. The long preface should already
+    # be marked spoken so it doesn't fire here either.
+    sent.clear()
+    client.handle_cc_stop(
+        {"session_id": "session-Q", "transcript_path": str(transcript)}
+    )
+    assert sent == []
+
+
 def test_stop_falls_back_to_last_text_when_no_unspoken(tmp_path, monkeypatch):
     """Empty transcript edge case: still produce SOMETHING via the
     legacy fallback so we never go silent."""


### PR DESCRIPTION
## Summary

- PreToolUse hook is registered `async: true`, so CC shows the AskUserQuestion popup before our hook can read the transcript, send to the daemon, and synthesise. Long prose prefaces ("Quick clarifying question before…") were landing several seconds after the user had already answered, and `Stop` was then re-narrating the same prose for good measure.
- Special-case `AskUserQuestion` in `handle_cc_pre_tool`: silently mark the unspoken transcript prose as spoken so `Stop` won't replay it, then forward the question itself through the existing `tool_question` template.
- The template now flips Haiku eligibility on (`recent_intent` set), and `persona._build_user_message` gets a `tool_question` branch that asks Haiku for one short spoken sentence ("Quick question: …") instead of the 2-4 word phrase the generic `tool_pre` prompt would emit. Synth budget shrinks from "the whole question verbatim" to one summarised sentence, which lands close to when the popup appears.

Stacks on top of `fix(narration): wait for transcript flush in PreToolUse` (the prior commit on this branch).

## Test plan

- [x] `pytest -q` (353 passed, 1 skipped — pre-existing `test_multi_agent` flakiness is independent of this change)
- [x] `ruff check heard/ tests/`
- [x] New unit test in `tests/test_intermediate_text.py` covers both halves: `PreToolUse` fires once with `recent_intent` populated, and the trailing `Stop` emits nothing because the preface is already marked spoken.
- [x] Hot-patched into `/Applications/Heard.app` and triggered an AskUserQuestion live — narration landed in time with the popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)