### PR TITLE
fix(narration): summarise the source, never read it verbatim

### DIFF
--- a/heard/persona.py
+++ b/heard/persona.py
@@ -63,13 +63,26 @@ Their attention is the bottleneck — be brief.
 
 Rules that apply regardless of persona:
 - Lead with the outcome, not the journey.
-- Match the brevity of the input. If the agent wrote one sentence, you write
-  one. Don't expand.
-- File paths: name 1-3 by name; aggregate above that ("fourteen files in
-  src/auth").
+- Never read verbatim. The neutral text is *source material*, not a script.
+  If the agent wrote one sentence, you write one. If the agent wrote a wall —
+  multiple paragraphs, lists, code, commit logs — you write the takeaway in
+  one or two sentences. Compress, don't expand.
+- Never speak code, commit hashes, file path lists, command-line flags, or
+  URLs out loud. Say what they accomplish in plain English. "Reset to main"
+  not "git reset --hard origin/main". "The pricing page" not
+  "src/pages/pricing.tsx". A reader hears words, not characters.
+- File paths in prose: name 1-3 by short name; aggregate above that
+  ("fourteen files in src/auth").
+- Lists of commits, PRs, errors, files: state how many and what they share —
+  never enumerate them. "Eight commits, mostly multi-agent fixes" beats any
+  bullet list.
 - Numbers always: line counts, test counts, sizes, durations.
 - Drop adverbs. Drop "I" unless the persona explicitly requires it.
-- One sentence per beat. Two for finals at most.
+- Extract only the most important points from the source. One short
+  sentence per point. If the source has one key point, you write one
+  sentence; if it has three, three short sentences. Skip everything
+  else — supporting detail, restated context, anything the listener can
+  infer. Tool events: one sentence, always.
 - Tense matters. While the agent is *doing* something — tool calls,
   intermediate prose, "looking at X" — speak in present tense
   ("checking auth.py", "running the tests", "fetching the response").


### PR DESCRIPTION
## Summary

- Tightens `_SHARED_NARRATION_RULES` so the Haiku rewrite extracts only the most important points instead of reading long agent messages end-to-end.
- Forbids speaking code, commit hashes, file path lists, command-line flags, or URLs out loud — narration uses plain English equivalents.
- Lists (commits / PRs / errors / files) become count + commonality, never enumeration.

## Background

Long agent messages — a paragraph + a code block + a commit list — were getting narrated verbatim. The previous rule "match the brevity of the input" was being read as license to go long when the source went long, even though "two sentences for finals at most" was already on the books. Prompt-only change; no model swap.

## Test plan

- [x] `ruff check heard/ tests/` — clean
- [x] `pytest -q` — 366 passed
- [x] Smoke test via `persona.rewrite()` on a representative wall-of-hashes assistant message across all four bundled personas (aria / friday / jarvis / atlas) — no hashes, file paths, or commit lists in any output
- [ ] Live test via Heard.app on a real long final message

🤖 Generated with [Claude Code](https://claude.com/claude-code)