### PR TITLE
chore: remove dead code (unused functions + tests-only legacy paths)

### DIFF
--- a/heard/client.py
+++ b/heard/client.py
@@ -591,30 +591,6 @@ def extract_assistant_texts_from(
     return out, end
 
 
-def extract_assistant_texts(transcript_path: str) -> list[str]:
-    """Full-file read (offset 0). Kept for back-compat; new callers
-    should prefer the offset-aware version above."""
-    out: list[str] = []
-    try:
-        with open(transcript_path, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    msg = json.loads(line)
-                except Exception:
-                    continue
-                if msg.get("type") != "assistant":
-                    continue
-                for c in msg.get("message", {}).get("content", []):
-                    if c.get("type") != "text":
-                        continue
-                    t = (c.get("text") or "").strip()
-                    if t:
-                        out.append(t)
-    except Exception:
-        pass
-    return out
-
-
 def _session_from_data(data: dict) -> dict:
     return {
         "id": data.get("session_id") or "default",

--- a/heard/hotkey.py
+++ b/heard/hotkey.py
@@ -52,7 +52,6 @@ Examples: ``<shift>+<alt>+.``, ``<cmd>+<shift>+,``, ``<ctrl>+/``.
 from __future__ import annotations
 
 import sys
-import threading
 from collections.abc import Callable
 
 DEFAULT_PAUSE_BINDING = "<shift>+<alt>+."
@@ -282,10 +281,3 @@ def _log_failure(e: Exception) -> None:
         )
     else:
         print(f"hotkey listener failed: {e}", file=sys.stderr, flush=True)
-
-
-def _noop_thread() -> threading.Thread:
-    """Placeholder used in tests or when hotkey_enabled is False."""
-    t = threading.Thread(target=lambda: None, daemon=True)
-    t.start()
-    return t

--- a/heard/multi_agent.py
+++ b/heard/multi_agent.py
@@ -764,10 +764,6 @@ class MultiAgentRouter:
         with self._lock:
             self._pinned = None
 
-    def pinned_session_id(self) -> str | None:
-        with self._lock:
-            return self._pinned
-
     # --- digest -----------------------------------------------------------
 
     def add_to_digest(

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -304,10 +304,6 @@ _PRO_PERSONAS = frozenset({"atlas", "friday"})
 _PERSONA_ORDER = ("jarvis", "aria", "friday", "atlas")
 
 
-def is_pro_persona(name: str) -> bool:
-    return name in _PRO_PERSONAS
-
-
 def list_bundled(plan: str = "pro") -> list[str]:
     """Return persona names available to the given plan, in display
     order (jarvis, aria, friday, atlas). Pro/trial get the full

--- a/heard/providers.py
+++ b/heard/providers.py
@@ -25,7 +25,6 @@ import subprocess
 import tempfile
 import urllib.error
 import urllib.request
-from typing import Protocol
 
 HAIKU_MODEL = "claude-haiku-4-5-20251001"
 
@@ -38,15 +37,6 @@ _CLAUDE_PATH_FALLBACKS = (
     os.path.expanduser("~/.volta/bin/claude"),
     os.path.expanduser("~/.local/bin/claude"),
 )
-
-
-class NarrationProvider(Protocol):
-    name: str
-
-    def rewrite(
-        self, system: str, user: str, max_tokens: int, timeout: float
-    ) -> str | None:
-        ...
 
 
 class AnthropicAPIProvider:
@@ -207,11 +197,3 @@ def _find_claude_binary() -> str | None:
         if os.path.isfile(cand) and os.access(cand, os.X_OK):
             return cand
     return None
-
-
-def get_provider(api_key: str = "") -> NarrationProvider | None:
-    """API if a key is set, else CLI if `claude` is on disk, else None."""
-    if (api_key or "").strip():
-        return AnthropicAPIProvider(api_key=api_key.strip())
-    binary = _find_claude_binary()
-    return ClaudeCLIProvider(binary=binary) if binary else None

--- a/heard/session.py
+++ b/heard/session.py
@@ -87,13 +87,6 @@ class SessionStore:
             if sess is not None:
                 sess["failure_count"] = (sess.get("failure_count") or 0) + 1
 
-    def note_success(self, session_id: str) -> None:
-        """Decay failure count on any successful tool event."""
-        with self._lock:
-            sess = self._sessions.get(session_id)
-            if sess is not None and sess.get("failure_count"):
-                sess["failure_count"] = max(0, sess["failure_count"] - 1)
-
     def note_topic(self, session_id: str, topic: str) -> None:
         with self._lock:
             sess = self._sessions.get(session_id)

--- a/heard/verbosity.py
+++ b/heard/verbosity.py
@@ -8,9 +8,7 @@ Each event passes through three gates:
 
 Returns are STRINGS so the daemon can route each outcome
 appropriately — silent drop, accumulate-for-digest, or send through
-the queue. The legacy ``should_narrate_pre`` / ``should_narrate_post``
-boolean wrappers stay for backwards compat with tests and a couple
-of older callers.
+the queue.
 
 The actual decisions come from profile dicts (heard/profile.py). The
 config keys ``verbosity`` and ``swarm_verbosity`` name profiles;
@@ -20,7 +18,6 @@ solo / focus events use ``verbosity``, swarm non-focus events use
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from heard import profile as profile_mod
@@ -43,14 +40,8 @@ _FAILURE_TAGS = ("tool_post_failure", "tool_post_command_failed")
 
 
 def _resolve_profile(cfg: dict[str, Any]) -> dict[str, Any]:
-    """Resolve the active profile for the focus / solo event path.
-    Multi-agent non-focus events route through ``classify_*_for_swarm``
-    which loads ``swarm_verbosity`` instead."""
+    """Resolve the active profile for the focus / solo event path."""
     return profile_mod.load(cfg.get("verbosity"), config_dir=_user_config_dir(cfg))
-
-
-def _resolve_swarm_profile(cfg: dict[str, Any]) -> dict[str, Any]:
-    return profile_mod.load(cfg.get("swarm_verbosity") or "brief", config_dir=_user_config_dir(cfg))
 
 
 def _user_config_dir(cfg: dict[str, Any]):
@@ -78,17 +69,6 @@ def classify_pre(cfg: dict[str, Any], tag: str, density: int) -> str:
     if tag == "tool_question":
         return "speak"
     prof = _resolve_profile(cfg)
-    return _classify_pre_with_profile(prof, tag, density)
-
-
-def classify_pre_for_swarm(cfg: dict[str, Any], tag: str, density: int) -> str:
-    """Variant for non-focus events in swarm mode — uses
-    ``swarm_verbosity`` profile (default "brief")."""
-    if not cfg.get("narrate_tools", True):
-        return "drop"
-    if tag == "tool_question":
-        return "speak"
-    prof = _resolve_swarm_profile(cfg)
     return _classify_pre_with_profile(prof, tag, density)
 
 
@@ -130,43 +110,3 @@ def classify_prose(cfg: dict[str, Any]) -> str:
     A silent profile (Quiet) drops them; everything else speaks."""
     prof = _resolve_profile(cfg)
     return "speak" if prof.get("prose") == "speak" else "drop"
-
-
-def final_char_budget(cfg: dict[str, Any]) -> int:
-    return int(_resolve_profile(cfg).get("final_budget", 600))
-
-
-# --- legacy boolean wrappers (back-compat) ---------------------------
-
-
-def should_narrate_pre(cfg: dict[str, Any], tag: str, density: int) -> bool:
-    """Legacy: True if we'd speak, False otherwise. Maps the new
-    "digest" decision to True so old callers route correctly through
-    the daemon's pre-existing flow (it'll then re-classify)."""
-    return classify_pre(cfg, tag, density) != "drop"
-
-
-def should_narrate_post(cfg: dict[str, Any], tag: str) -> bool:
-    return classify_post(cfg, tag) == "speak"
-
-
-# --- summarisation utility (unchanged) -------------------------------
-
-
-def truncate_to_sentences(text: str, max_chars: int) -> str:
-    """Used as a fallback summariser when Haiku is unavailable. Cuts
-    at a sentence boundary below the budget."""
-    text = text.strip()
-    if len(text) <= max_chars:
-        return text
-    sentences = re.split(r"(?<=[.!?])\s+", text)
-    out: list[str] = []
-    total = 0
-    for s in sentences:
-        if total + len(s) + 1 > max_chars and out:
-            break
-        out.append(s)
-        total += len(s) + 1
-    if not out:
-        return text[: max_chars - 1].rsplit(" ", 1)[0] + "…"
-    return " ".join(out)

--- a/heard/working_memory.py
+++ b/heard/working_memory.py
@@ -96,10 +96,6 @@ class WorkingMemoryState:
     compressed_at: float = 0.0  # monotonic time of last successful compression
     events_at_compression: int = 0  # event_count at last compression — used to detect "new since last"
 
-    def is_stale(self, *, now: float | None = None) -> bool:
-        now = time.monotonic() if now is None else now
-        return self.compressed_at == 0.0 or (now - self.compressed_at) > COMPRESS_TICK_S
-
 
 @dataclass
 class _EventBufferEntry:

--- a/tests/test_intermediate_text.py
+++ b/tests/test_intermediate_text.py
@@ -41,23 +41,6 @@ def _write_transcript(path: Path, blocks: list) -> None:
     path.write_text("\n".join(lines) + "\n")
 
 
-def test_extract_assistant_texts_returns_each_block_in_order(tmp_path):
-    transcript = tmp_path / "t.jsonl"
-    _write_transcript(
-        transcript,
-        [
-            ("user", [{"type": "text", "text": "go"}]),
-            ("assistant", [{"type": "text", "text": "First prose."}]),
-            ("assistant", [{"type": "tool_use", "name": "Bash"}]),
-            ("assistant", [{"type": "text", "text": "Second prose."}]),
-            ("assistant", [{"type": "tool_use", "name": "Bash"}]),
-            ("assistant", [{"type": "text", "text": "Final prose."}]),
-        ],
-    )
-    texts = client.extract_assistant_texts(str(transcript))
-    assert texts == ["First prose.", "Second prose.", "Final prose."]
-
-
 def test_filter_unspoken_skips_already_marked():
     spoken.mark_spoken("s1", "First prose.")
     out = spoken.filter_unspoken("s1", ["First prose.", "Second prose.", "First prose."])

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -194,7 +194,6 @@ def test_unpin_returns_to_auto_mode():
 def test_pin_unknown_session_returns_false():
     r = _new_router()
     assert r.pin("not-a-real-session") is False
-    assert r.pinned_session_id() is None
 
 
 def test_solo_after_inactive_threshold():

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -67,16 +67,3 @@ def test_partial_user_yaml_falls_back_to_defaults(tmp_path):
 def test_list_bundled_returns_four():
     names = profile.list_bundled()
     assert {"quiet", "brief", "normal", "verbose"}.issubset(set(names))
-
-
-def test_swarm_profile_resolves_via_classify():
-    """Verbosity classify_pre_for_swarm uses the swarm_verbosity
-    config key — defaults to brief if unset."""
-    from heard import verbosity
-
-    # Explicit swarm_verbosity wins.
-    cfg = {"narrate_tools": True, "swarm_verbosity": "quiet"}
-    assert verbosity.classify_pre_for_swarm(cfg, "tool_edit", density=0) == "drop"
-    # Default is brief — routine tools digest, prose speaks.
-    cfg_default = {"narrate_tools": True}
-    assert verbosity.classify_pre_for_swarm(cfg_default, "tool_edit", density=0) == "digest"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -9,15 +9,6 @@ from types import SimpleNamespace
 from heard import providers
 
 
-def test_get_provider_picks_right_backend(monkeypatch):
-    monkeypatch.setattr(providers, "_find_claude_binary", lambda: "/fake/claude")
-    assert isinstance(providers.get_provider(api_key="sk-x"), providers.AnthropicAPIProvider)
-    assert isinstance(providers.get_provider(api_key=""), providers.ClaudeCLIProvider)
-
-    monkeypatch.setattr(providers, "_find_claude_binary", lambda: None)
-    assert providers.get_provider(api_key="") is None
-
-
 def test_cli_subprocess_is_locked_down(monkeypatch):
     """Verify the safety contract: no tool calls, user-level settings
     skipped, hook latch set, and the subprocess runs from a tempdir so

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -17,15 +17,6 @@ def test_touch_idempotent_does_not_reset_failures():
     assert store.get("abc")["failure_count"] == 2
 
 
-def test_note_success_decays_failures():
-    store = SessionStore()
-    store.touch("abc", cwd="/r")
-    store.note_failure("abc")
-    store.note_failure("abc")
-    store.note_success("abc")
-    assert store.get("abc")["failure_count"] == 1
-
-
 def test_note_topic_sets_last_topic():
     store = SessionStore()
     store.touch("abc", cwd="/r")

--- a/tests/test_verbosity.py
+++ b/tests/test_verbosity.py
@@ -13,27 +13,25 @@ def test_level_respects_config():
     assert verbosity.level({"verbosity": "brief"}) == "brief"
 
 
-def test_should_narrate_pre_low_keeps_long_running():
+def test_classify_pre_low_keeps_long_running():
     cfg = {"narrate_tools": True, "verbosity": "low"}
-    assert verbosity.should_narrate_pre(cfg, "tool_bash_test", density=0) is True
-    assert verbosity.should_narrate_pre(cfg, "tool_bash_build", density=0) is True
-    assert verbosity.should_narrate_pre(cfg, "tool_edit", density=0) is False
+    assert verbosity.classify_pre(cfg, "tool_bash_test", density=0) == "speak"
+    assert verbosity.classify_pre(cfg, "tool_bash_build", density=0) == "speak"
+    assert verbosity.classify_pre(cfg, "tool_edit", density=0) == "drop"
 
 
-def test_should_narrate_pre_question_always_speaks():
+def test_classify_pre_question_always_speaks():
     cfg_low = {"narrate_tools": True, "verbosity": "low"}
     cfg_dense = {"narrate_tools": True, "verbosity": "normal"}
-    assert verbosity.should_narrate_pre(cfg_low, "tool_question", density=0) is True
-    assert verbosity.should_narrate_pre(cfg_dense, "tool_question", density=999) is True
+    assert verbosity.classify_pre(cfg_low, "tool_question", density=0) == "speak"
+    assert verbosity.classify_pre(cfg_dense, "tool_question", density=999) == "speak"
 
 
-def test_should_narrate_pre_normal_routes_burst_to_digest():
-    """At normal verbosity, density >5 in 30s used to silently drop
-    routine pre-tool announcements. New behaviour: route them to the
-    multi-agent digest queue so they're summarised on the next prose
-    arrival ("3 edits, ran tests."), not lost. classify_pre returns
-    'speak'/'drop'/'digest' explicitly; the legacy bool wrapper
-    treats digest as truthy."""
+def test_classify_pre_normal_routes_burst_to_digest():
+    """At normal verbosity, density >5 in 30s routes routine pre-tool
+    announcements to the multi-agent digest queue so they're summarised
+    on the next prose arrival ("3 edits, ran tests."), not lost.
+    classify_pre returns 'speak'/'drop'/'digest' explicitly."""
     cfg = {"narrate_tools": True, "verbosity": "normal"}
     # Below threshold: speak each tool.
     assert verbosity.classify_pre(cfg, "tool_edit", density=3) == "speak"
@@ -69,39 +67,25 @@ def test_quiet_drops_prose_speaks_long_running():
     assert verbosity.classify_pre(cfg, "tool_bash_test", density=0) == "speak"
 
 
-def test_should_narrate_pre_high_always_speaks():
+def test_classify_pre_high_density_routes_to_digest_not_drop():
+    """A regular tool over the burst threshold accumulates into the
+    digest rather than dropping — even at verbose."""
     cfg = {"narrate_tools": True, "verbosity": "high"}
-    assert verbosity.should_narrate_pre(cfg, "tool_edit", density=100) is True
+    assert verbosity.classify_pre(cfg, "tool_edit", density=100) != "drop"
 
 
-def test_should_narrate_post_failures_always():
+def test_classify_post_failures_always():
     for lv in ("low", "normal", "high"):
         cfg = {"narrate_tools": True, "narrate_tool_results": True, "verbosity": lv}
-        assert verbosity.should_narrate_post(cfg, "tool_post_failure") is True
-        assert verbosity.should_narrate_post(cfg, "tool_post_command_failed") is True
+        assert verbosity.classify_post(cfg, "tool_post_failure") == "speak"
+        assert verbosity.classify_post(cfg, "tool_post_command_failed") == "speak"
 
 
-def test_should_narrate_post_success_only_in_high():
+def test_classify_post_success_only_in_high():
     cfg_low = {"narrate_tools": True, "narrate_tool_results": True, "verbosity": "low"}
     cfg_high = {"narrate_tools": True, "narrate_tool_results": True, "verbosity": "high"}
-    assert verbosity.should_narrate_post(cfg_low, "tool_post_success") is False
-    assert verbosity.should_narrate_post(cfg_high, "tool_post_success") is True
-
-
-def test_truncate_preserves_short():
-    assert verbosity.truncate_to_sentences("Short.", 1000) == "Short."
-
-
-def test_truncate_cuts_at_sentence():
-    text = "One. Two. Three. Four. Five."
-    out = verbosity.truncate_to_sentences(text, 12)
-    assert out == "One. Two."
-
-
-def test_final_char_budget():
-    assert verbosity.final_char_budget({"verbosity": "low"}) == 200
-    assert verbosity.final_char_budget({"verbosity": "normal"}) == 600
-    assert verbosity.final_char_budget({"verbosity": "high"}) == 2000
+    assert verbosity.classify_post(cfg_low, "tool_post_success") == "drop"
+    assert verbosity.classify_post(cfg_high, "tool_post_success") == "speak"
 
 
 def test_narrate_tools_disabled_silences_pre_but_not_failures():
@@ -109,10 +93,10 @@ def test_narrate_tools_disabled_silences_pre_but_not_failures():
     pierce regardless — losing a "command failed" notification has a
     much worse cost than enduring a chatty success message."""
     cfg = {"narrate_tools": False, "verbosity": "high"}
-    assert verbosity.should_narrate_pre(cfg, "tool_bash_test", density=0) is False
+    assert verbosity.classify_pre(cfg, "tool_bash_test", density=0) == "drop"
     # Failures still speak — they're a separate signal class.
-    assert verbosity.should_narrate_post(cfg, "tool_post_failure") is True
-    assert verbosity.should_narrate_post(cfg, "tool_post_command_failed") is True
+    assert verbosity.classify_post(cfg, "tool_post_failure") == "speak"
+    assert verbosity.classify_post(cfg, "tool_post_command_failed") == "speak"
 
 
 def test_failures_always_speak_regardless_of_legacy_flag():
@@ -121,8 +105,8 @@ def test_failures_always_speak_regardless_of_legacy_flag():
     `narrate_failures: false` in someone's old config.yaml must NOT
     silence failures."""
     cfg = {"narrate_failures": False, "narrate_tools": True, "verbosity": "high"}
-    assert verbosity.should_narrate_post(cfg, "tool_post_failure") is True
-    assert verbosity.should_narrate_post(cfg, "tool_post_command_failed") is True
+    assert verbosity.classify_post(cfg, "tool_post_failure") == "speak"
+    assert verbosity.classify_post(cfg, "tool_post_command_failed") == "speak"
 
 
 def test_narrate_tool_results_disabled_keeps_failures():
@@ -133,5 +117,5 @@ def test_narrate_tool_results_disabled_keeps_failures():
         "narrate_tool_results": False,
         "verbosity": "high",
     }
-    assert verbosity.should_narrate_post(cfg, "tool_post_success") is False
-    assert verbosity.should_narrate_post(cfg, "tool_post_failure") is True
+    assert verbosity.classify_post(cfg, "tool_post_success") == "drop"
+    assert verbosity.classify_post(cfg, "tool_post_failure") == "speak"


### PR DESCRIPTION
Dead-code sweep over `main` (v1.0.19). Removes functions with zero callers, production functions kept alive only by their own tests, and the imports/private helpers they orphaned. **Behaviour-preserving** — no product path changes.

**−194 net lines** across 14 files. `ruff` clean, **740 tests pass** (was 747; 7 dead-function tests removed). `vulture` confirms every removed symbol is gone.

## Removed

**Truly dead (no callers anywhere):**
- `persona.is_pro_persona`
- `hotkey._noop_thread` (+ orphaned `threading` import)
- `working_memory.WorkingMemoryState.is_stale`

**Production-dead (only their own tests called them):**
- `verbosity`: `should_narrate_pre` / `should_narrate_post` (legacy bool wrappers), `final_char_budget`, `truncate_to_sentences` (+ `re` import), `classify_pre_for_swarm` (+ `_resolve_swarm_profile` helper)
- `client.extract_assistant_texts`
- `multi_agent.MultiAgentRouter.pinned_session_id`
- `session.SessionStore.note_success`
- `providers.get_provider` (+ `NarrationProvider` protocol + `Protocol` import)

## Test handling

Not a blanket delete. Where a removed wrapper's test asserted **live behaviour** (failures always pierce, the `narrate_tools` / `narrate_tool_results` gates), the test was **retargeted** to the live `classify_pre` / `classify_post` API so coverage survived. Only tests of functions with *no* live equivalent were deleted.

## ⚠️ Pre-existing finding (not fixed here)

Removing `classify_pre_for_swarm` exposes that **`swarm_verbosity` is a dead setting**: the Settings UI still writes it (`settings_window.py:1457`) and `cli.py` validates it, but the swarm classifier was its only reader — and that was already tests-only before this PR. The "swarm verbosity" picker currently does nothing. Left the config key + UI in place; flagging for a separate decision (re-wire swarm classification, or remove the orphaned setting + picker).

## Intentionally kept

- `heard_api` device cluster (`list_devices` / `revoke_device` / `DeviceInfo`) — planned "Connected Macs" scaffolding
- `client.from_claude_code_hook` — v0.1 back-compat hook entry point
- inert config flags `narrate_prompt_intent`, `auto_resume_on_mic_release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)