### PR TITLE
v1.0.21 — v1 sunset: mandatory brain + no-LLM floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,64 @@ CC tool call
   ↓ stdin: {"hook_event_name": "PreToolUse", ...}
 heard.client.send_event() → Unix socket
   ↓
-Heard.app (daemon thread)
+Heard.app (daemon thread) — _handle_event routes by kind:
+  ├─ tool_pre / tool_post  → fast-path templates (no LLM)   → speech queue
+  ├─ prose / finals        → harness (the brain, Layer 5)   → speech queue
+  └─ harness punts (None)  → no-LLM floor (canned/template) → speech queue
   ↓
-verbosity gate → multi_agent router → persona rewrite → speech queue → afplay
-  ↓
-history.append (after successful play)
+afplay → history.append (after successful play)
 ```
+
+**v1 is sunset (2026-06).** The brain is mandatory — there is no longer a
+`verbosity → multi_agent → persona.rewrite` fallback chain in the live path.
+See "v1 sunset" below for what was removed and what corpse code remains.
+
+## v1 sunset (2026-06)
+
+"v1" was the original narration pipeline: a per-event chain of
+`verbosity.classify → multi_agent.route → persona.rewrite` (a Haiku
+rewrite of the template "neutral" text), with a raw-template floor under
+it. The harness brain (Layer 5) started as an opt-in A/B *over* v1. As of
+this milestone the brain is **mandatory** and v1 is **removed from the
+live path**. There are now exactly three lanes (see the process diagram):
+
+1. **Brain** (`harness.narrate`) — prose + finals.
+2. **Fast-path templates** — tool actions ("Editing auth.py"); never the
+   brain (latency/cost). Cheap, no LLM.
+3. **No-LLM floor** (`Daemon._floor_text`) — when the brain punts (LLM
+   unreachable: managed daily cap, outage, no provider). Tools keep their
+   clean template; a **final** gets a short canned line ("That's done —
+   the details are in your terminal") rather than its raw text read
+   **verbatim** (the old "it read everything" bug); mid-stream prose is
+   dropped. A final genuinely can't be summarised without an LLM, so the
+   honest floor is "go look," not the wall.
+
+**What was deleted:** the ~164-line v1 branch in `Daemon._handle_event`
+(verbosity re-gate, `multi_agent.classify` routing, the `persona.rewrite`
+call, label-prefix application, `via=v1` analytics) and
+`_cap_runaway_prose` (the v1 verbatim-wall truncation cap).
+
+**Corpse code still in the tree (do NOT call, do NOT extend):**
+
+- `persona.rewrite()` + `_byok_/_managed_/_cli_haiku_rewrite` +
+  `_build_user_message` — the v1 Haiku-rewrite layer. Orphaned; kept only
+  because removing it means reworking ~10 persona tests. A future cleanup
+  pass should delete it. Still exercised by `tests/test_persona.py` and
+  `tests/test_prompt_intent.py` in isolation, which is the *only* reason
+  those call sites exist.
+
+**Still shared, NOT v1 (keep):** `templates.py` (the brain eats its
+"neutral" output as input; the fast-path speaks it), `verbosity.py` (the
+fast-path's tool gates), `multi_agent.py` (voices, digest, burst summaries,
+project routing — used by the fast-path and the digest tick). These look
+like v1 but are load-bearing for the live path.
+
+**Why keep a floor at all if the brain is mandatory?** The brain is an LLM
+call over the network — it has real failure modes (daily cap, outage, no
+provider). The floor (and the local-Kokoro TTS option) is what keeps Heard
+from going silent, which for an ambient tool reads as "broken." The fix was
+never "delete the safety net" — it was "make the net rare and make it sound
+fine when it fires."
 
 ## Module map
 
@@ -41,7 +93,7 @@ having no doc — future sessions trust this table.
 
 | File | Responsibility |
 |---|---|
-| `heard/daemon.py` | Long-running daemon. Owns the speech queue, hotkey listener, audio monitor, multi-agent router instance, history append, periodic digest timer. Also reads `config.silenced` on every event so "Pause Heard" (indefinite mute) survives quit + respawn. **Utterance tracking:** `_last_utterance_id` (UUID minted per speak request, stamped onto history record + retained so feedback can attach), `_last_utterance_finished_at` (monotonic seconds, lets `_record_implicit_feedback` decide if a pause/mic event falls within the correlation window), `_implicit_signals_recorded` (dedup set keyed by `(utterance_id, source)`, cleared on new utterance). **Implicit signal capture (Phase 2 step 3):** `_record_implicit_feedback(source, kind, defect_category)` wired into three points — after `proc.wait()` in `_speak` fires `afplay_nonzero` defects when afplay exits non-zero without us killing it, `_on_mic_active` fires `mic_collide` defect when speaking, `_do_mute` fires `pause_<source>` preference signal for user-initiated mutes. `IMPLICIT_WINDOW_S=5.0` gates preference correlation. Socket commands dispatched in `_handle()`: `ping`, `status`, `pin`, `unpin`, `reload`, `request_accessibility`, `stop`, `mute`, `unmute`, `resume_intent`, `feedback` (Phase 2 — writes preference via `history.append_feedback`), `report_defect` (Phase 2 — writes via `defects.append` with auto-attached tech_context: backend, voice, speed, persona, mic state, last_error), `ask` (Layer 4 Q&A — `project_memory.answer`, optional `speak`), `recap` (Layer 4 pull — `project_memory.recap`, question-less "catch me up" that re-summarizes recent project activity and speaks it; default `speak=True`), `mute_session` / `unmute_session` (per-session silence — adds/removes a `session_id` in the in-memory `_muted_sessions` set; muted sessions are still observed for state/memory but never narrated; mute also flushes that session's queued items. Driven by `/quiet` + `/unquiet` user slash commands), `event`. |
+| `heard/daemon.py` | Long-running daemon. Owns the speech queue, hotkey listener, audio monitor, multi-agent router instance, history append, periodic digest timer. **Narration routing (`_handle_event`):** tool events → fast-path templates; prose/finals → `harness.narrate`; harness punt → **`_floor_text` (the no-LLM v2 floor — see "v1 sunset")**. **`_is_duplicate_tool_line`** suppresses consecutive identical tool lines ("Reading a file." ×6 → ×1, `_TOOL_DUP_WINDOW_S=25`). Solo sessions (`router.list_active() < 2`) drop the repo-label prefix from digest summaries and skip the "Now on \<project\>" tag (`_with_project_tag`) — both are multi-agent-only disambiguation. Also reads `config.silenced` on every event so "Pause Heard" (indefinite mute) survives quit + respawn. **Utterance tracking:** `_last_utterance_id` (UUID minted per speak request, stamped onto history record + retained so feedback can attach), `_last_utterance_finished_at` (monotonic seconds, lets `_record_implicit_feedback` decide if a pause/mic event falls within the correlation window), `_implicit_signals_recorded` (dedup set keyed by `(utterance_id, source)`, cleared on new utterance). **Implicit signal capture (Phase 2 step 3):** `_record_implicit_feedback(source, kind, defect_category)` wired into three points — after `proc.wait()` in `_speak` fires `afplay_nonzero` defects when afplay exits non-zero without us killing it, `_on_mic_active` fires `mic_collide` defect when speaking, `_do_mute` fires `pause_<source>` preference signal for user-initiated mutes. `IMPLICIT_WINDOW_S=5.0` gates preference correlation. Socket commands dispatched in `_handle()`: `ping`, `status`, `pin`, `unpin`, `reload`, `request_accessibility`, `stop`, `mute`, `unmute`, `resume_intent`, `feedback` (Phase 2 — writes preference via `history.append_feedback`), `report_defect` (Phase 2 — writes via `defects.append` with auto-attached tech_context: backend, voice, speed, persona, mic state, last_error), `ask` (Layer 4 Q&A — `project_memory.answer`, optional `speak`), `recap` (Layer 4 pull — `project_memory.recap`, question-less "catch me up" that re-summarizes recent project activity and speaks it; default `speak=True`), `mute_session` / `unmute_session` (per-session silence — adds/removes a `session_id` in the in-memory `_muted_sessions` set; muted sessions are still observed for state/memory but never narrated; mute also flushes that session's queued items. Driven by `/quiet` + `/unquiet` user slash commands), `event`. |
 | `heard/client.py` | Hook-side helpers: spawn the daemon if needed, send events / status / pin commands over the Unix socket. Six `handle_cc_*` / `handle_codex_*` event handlers (CC ↔ Codex pairs are near-duplicates — collapse candidate; the post-tool pair is byte-identical). |
 | `heard/hook.py` | Entry-point invoked by the agent's hook command. Routes to `client.handle_cc_*` / `client.handle_codex_*`. |
 | `heard/wrapper.py` | `heard run <cmd> [args...]` — universal terminal wrapper. Spawns an agent, tees its stdout, and synthesizes events for agents without a native hook surface. |
@@ -50,10 +102,10 @@ having no doc — future sessions trust this table.
 | `heard/session.py` | In-memory per-session state (id + cwd + timestamps) held by the daemon. Keyed by transcript path. Smaller / older bookkeeping; the multi-agent router relies on it. Sibling to `agent_state.py` (richer scoreboard). |
 | `heard/agent_state.py` | **Layer 2 — Agent State (the "scoreboard").** Per-agent record with facts (current_tool, last_tool, last_tool_duration, files_touched, error_count, recent_output_tokens, last_user_input_at) + cheap heuristic hints (`response_shape_hint`: short-execution/long-deliberation/mixed; `salience_hint`: active-decision/routine/blocked). **Boundary rule: never an LLM, never a decision** — if it can be computed by a Python function from raw event data, it's Layer 2; otherwise it's Layer 5. `AgentStateRegistry` is the daemon-owned instance; `observe(event)` updates state from one event payload; `summary()` returns the active-agent snapshot the daemon publishes in its status reply. Read by `heard status` and by the harness on every meaningful event. |
 | `heard/working_memory.py` | **Layer 3 — Working Memory (Phase 3 step 7).** Short rolling prose summary of "what's going on right now" across the active agents. Two paths: (a) hot-path `observe(event)` appends to a small ring buffer (cap `EVENT_BUFFER_KEEP=40`); (b) background compressor thread (started by daemon) runs every ~5s and calls `maybe_compress()` — gates on `COMPRESS_TICK_S=30` elapsed OR `COMPRESS_NEW_EVENT_THRESHOLD=12` new events since last compression. Compression dispatches via `persona.call_with_prompt(log_path_label="wm_compress")` with the previous prose + recent events + Agent State summary as input; new prose atomic-swaps the snapshot under `_state_lock` so `snapshot()` always returns a consistent string in O(1). **Stale-tolerant by design:** failed compression / "(idle)" / empty response do NOT bash the previous good summary — the harness keeps reading whatever was there. Daemon starts the compressor in `__init__` and stops it on `shutdown()`. |
-| `heard/harness.py` | **Layer 5 — Harness Agent (NARRATE-only prototype, Phase 3 step 6).** The make-or-break A/B for the v2 architecture. Gated by `cfg["harness_enabled"]` (off by default — zero impact on v1 path). When on, `narrate(event, cfg, persona, agent_states, working_memory)` builds a cached system block (persona + cross-persona rules + `_HARNESS_INSTRUCTION_BLOCK` + prefs stub) + dynamic user message (rolling-summary stub + active-agent snapshot ranked by salience + current event), dispatches via `persona.call_with_prompt` (uses prompt caching + observability), and returns a `HarnessDecision`. Three outcomes: `None` → daemon falls back to v1 (safety net); `speak=False` → harness chose silence, daemon suppresses; `speak=True` → daemon enqueues `decision.text` directly, bypassing v1. Working Memory is `""` for now — Phase 3 step 7 will fill in. `MAX_AGENTS_IN_PROMPT=8` caps the dynamic prefix. Prompt assembly is pure (`_build_system_text`, `_build_user_message`, `_rank_agents_by_salience`, `_render_event_compact`) so it's unit-testable without the LLM. |
+| `heard/harness.py` | **Layer 5 — Harness Agent. The mandatory narration brain** (v1 sunset, 2026-06). `is_enabled()` now always returns True — the old `cfg["harness_enabled"]` A/B flag is inert. `narrate(event, cfg, persona, agent_states, working_memory)` builds a cached system block (persona + cross-persona rules + `_HARNESS_INSTRUCTION_BLOCK` + prefs stub) + dynamic user message (rolling-summary + active-agent snapshot ranked by salience + current event), dispatches via `persona.call_with_prompt` (prompt caching + observability, **one retry on a transient blip**), and returns a `HarnessDecision`. Three outcomes: `None` → **daemon's no-LLM floor** (NOT v1 — that's gone); `speak=False` → harness chose silence; `speak=True` → daemon enqueues `decision.text`. `should_use_fast_path()` decides which events skip the brain (tool_pre/tool_post → templates; prose/finals/repeat-edits/cross-agent → brain). `MAX_AGENTS_IN_PROMPT=8` caps the dynamic prefix. Prompt assembly is pure (`_build_system_text`, `_build_user_message`, `_rank_agents_by_salience`, `_render_event_compact`) so it's unit-testable without the LLM. |
 | `heard/profile.py` + `heard/profiles/*.yaml` | Verbosity profiles (quiet / brief / normal / verbose). Five dimensions per profile: `pre_tool`, `post_success`, `prose`, `final_budget`, `burst_threshold`. User dir overrides bundled. |
 | `heard/verbosity.py` | Three-way classifier: `classify_pre` → `speak/drop/digest`. Failures + questions always pierce. Long-running tags (`tool_bash_test` etc.) pierce even at quiet/digest. |
-| `heard/persona.py` | Persona load + Haiku rewrite dispatcher. `_SHARED_NARRATION_RULES` is the cross-persona framing every Haiku call gets. `_build_user_message` adds tense rules per event_kind. Three rewrite paths live here today: `_byok_haiku_rewrite` (BYOK Anthropic), `_managed_haiku_rewrite` (Heard cloud), `_cli_haiku_rewrite` (`claude -p` fallback). Model: `claude-haiku-4-5-20251001`. Dispatcher should eventually move into `heard/providers.py`. **Prompt caching:** BYOK + managed paths wrap the system block in `cache_control: ephemeral` (no-op below the 2048-token Haiku threshold; activates when the harness pushes past it). `_log_haiku_cache_usage(msg, path)` logs `haiku_cache event=... input=N cache_read=N cache_write=N` so the step-6 A/B has real cache observability. **`call_with_prompt(system_text, user_msg, *, max_tokens, timeout_s, log_path_label)`** is the public helper Layer 5 uses to dispatch its own (system, user) prompt pair without going through the event-rewrite shape. BYOK Anthropic → managed proxy ladder only (no OpenAI / CLI fallback inside) since the harness prototype wants a deterministic call path. |
+| `heard/persona.py` | Persona load + LLM dispatch. `_SHARED_NARRATION_RULES` is the cross-persona framing. **`call_with_prompt(...)` is the live entry point** — the harness brain (Layer 5) and `summarize_project` (burst digests) both dispatch through it. **`rewrite(...)` and its `_byok_/_managed_/_cli_haiku_rewrite` helpers are ORPHANED (v1 sunset, 2026-06)** — the per-event Haiku-rewrite path the daemon's deleted v1 branch used to call. Kept as dead code for now (removing them means reworking ~10 persona tests); they are NOT in any live narration path. Don't add new callers. Model: `claude-haiku-4-5-20251001`. **Prompt caching:** the managed/BYOK paths wrap the system block in `cache_control: ephemeral`; `_log_haiku_cache_usage` logs `haiku_cache event=... input=N cache_read=N cache_write=N`. **Prompt caching:** BYOK + managed paths wrap the system block in `cache_control: ephemeral` (no-op below the 2048-token Haiku threshold; activates when the harness pushes past it). `_log_haiku_cache_usage(msg, path)` logs `haiku_cache event=... input=N cache_read=N cache_write=N` so the step-6 A/B has real cache observability. **`call_with_prompt(system_text, user_msg, *, max_tokens, timeout_s, log_path_label)`** is the public helper Layer 5 uses to dispatch its own (system, user) prompt pair without going through the event-rewrite shape. BYOK Anthropic → managed proxy ladder only (no OpenAI / CLI fallback inside) since the harness prototype wants a deterministic call path. |
 | `heard/providers.py` | Provider abstraction for the narration LLM. Partially-finished extraction — the three rewrite paths in `persona.py` are still inline. |
 | `heard/personas/*.md` | Bundled personas (aria, friday, jarvis, atlas). YAML frontmatter (voice/speed/verbosity/narrate_tools/address) + Markdown body (Haiku system prompt). |
 | `heard/templates.py` | Per-tool narration templates. `_bash_tag_and_text` extracts intent from shell verbs (grep → search, ls → list, etc.). `_first_token` handles `cd && grep` compound commands. |

--- a/heard/__init__.py
+++ b/heard/__init__.py
@@ -10,7 +10,7 @@ import os
 # bundle the updater reads CFBundleShortVersionString from Info.plist
 # instead, so a missed bump here won't trigger a phantom "update"
 # banner — see heard.updater.resolved_current_version.)
-__version__ = "1.0.20"
+__version__ = "1.0.21"
 
 # The frozen Python inside Heard.app has no system CA path, so any
 # HTTPS call (urllib voice download, anthropic SDK, elevenlabs SDK)

--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -285,6 +285,15 @@ class Daemon:
         self._recent_edit_paths: collections.deque[str] = collections.deque(
             maxlen=8,
         )
+        # Per-session recently-spoken tool lines, for consecutive-duplicate
+        # suppression. A burst of reads all render the same template
+        # ("Reading a file.") and a run of greps render "Searching the
+        # codebase." — narrating each one is the robotic-repetition
+        # complaint. We speak the first, then drop identical repeats within
+        # a short window. Keyed by session_id → deque[(text, monotonic)].
+        self._recent_tool_lines: dict[str, collections.deque] = (
+            collections.defaultdict(lambda: collections.deque(maxlen=12))
+        )
         # Per-session mute. Holds the session_ids the user has silenced
         # via /quiet — events from these are observed (state/memory stay
         # complete) but never narrated, until /unquiet. In-memory: a
@@ -684,7 +693,12 @@ class Daemon:
                     # it (fresh start) via the same socket cmd.
                     continue
                 flushes = self.router.collect_project_flushes(auto_voices=auto_voices)
+                # Solo when the whole fleet is one agent on one project —
+                # then the summary skips the repo label ("Read through the
+                # auth flow, tests passed" not "Heard: …").
+                solo_fleet = len(self.router.list_active()) <= 1
                 for pf in flushes:
+                    is_solo = solo_fleet and len(pf.member_session_ids) <= 1
                     # Prefer the LLM-narrative summary ("On the API
                     # project, edited the auth flow across three files;
                     # tests passed"). Falls back to the deterministic
@@ -695,10 +709,13 @@ class Daemon:
                         pf.label,
                         pf.events,
                         member_count=len(pf.member_session_ids),
+                        solo=is_solo,
                     )
                     if not summary:
                         summary = multi_agent_mod.format_project_summary(
-                            pf.label, pf.events, member_count=len(pf.member_session_ids)
+                            pf.label, pf.events,
+                            member_count=len(pf.member_session_ids),
+                            include_label=not is_solo,
                         )
                     if not summary:
                         continue
@@ -1827,6 +1844,15 @@ class Daemon:
         proj = self._project_label(hmeta)
         if not proj:
             return text
+        # Solo (single active agent) → never announce the project. There's
+        # only one; "Now on heard." every time the tracker resets is the
+        # "constantly saying the name of the repo" complaint. The tag earns
+        # its keep only when 2+ agents run in parallel and the listener
+        # genuinely needs to know which one is talking. Still update the
+        # tracker so a later switch into multi-agent is detected correctly.
+        if len(self.router.list_active()) < 2:
+            self._last_spoken_project = proj
+            return text
         if proj != self._last_spoken_project:
             self._last_spoken_project = proj
             _log("project_switch_tag", project=proj)
@@ -2140,6 +2166,27 @@ class Daemon:
 
     # --- event handling -----------------------------------------------------
 
+    # Window within which an identical tool template line is treated as a
+    # repeat and suppressed. Long enough to swallow a tight read/search
+    # burst; short enough that a genuinely new beat 30s later still speaks.
+    _TOOL_DUP_WINDOW_S = 25.0
+
+    def _is_duplicate_tool_line(self, session_id: str, text: str) -> bool:
+        """True if ``text`` was already spoken for this session within
+        ``_TOOL_DUP_WINDOW_S``. Records ``text`` either way so the next
+        repeat is caught. Case/space-insensitive match so trivial
+        formatting differences still de-dupe."""
+        sig = " ".join(text.lower().split())
+        now = time.monotonic()
+        recent = self._recent_tool_lines[session_id]
+        # Drop expired entries from the front-ish (cheap linear scan; the
+        # deque is capped at 12).
+        is_dup = any(
+            s == sig and (now - ts) <= self._TOOL_DUP_WINDOW_S for s, ts in recent
+        )
+        recent.append((sig, now))
+        return is_dup
+
     def _handle_event(self, req: dict) -> None:
         kind = req.get("kind") or ""
         neutral = (req.get("neutral") or "").strip()
@@ -2277,6 +2324,16 @@ class Daemon:
                         return
                 if not neutral:
                     _log("event_drop", kind=kind, tag=tag, reason="fastpath_empty_neutral")
+                    return
+                # Consecutive-duplicate suppression. A run of reads /
+                # searches renders the same template line over and over
+                # ("Reading a file." × 6); speak the first, drop the
+                # echoes within a short window. Tool kinds only — prose
+                # and finals are never deduped this way.
+                if kind in ("tool_pre", "tool_post") and self._is_duplicate_tool_line(
+                    session_id, neutral
+                ):
+                    _log("event_drop", kind=kind, tag=tag, reason="fastpath_dup_tool_line")
                     return
                 info = self.router._sessions.get(session_id)  # noqa: SLF001
                 history_meta = {
@@ -2476,7 +2533,13 @@ class Daemon:
             # prose plays — gives the user a coherent "Made 3 edits,
             # ran tests. OK, all green." narrative instead of stale
             # tool announcements queueing up behind the prose.
-            summary = self.router.drain_session_summary(session_id)
+            # Only prefix the repo label when 2+ agents are active —
+            # in a solo session "Heard: 3 reads" is just noise; the
+            # listener knows which project they're in.
+            multi_active = len(self.router.list_active()) > 1
+            summary = self.router.drain_session_summary(
+                session_id, include_label=multi_active
+            )
             if summary:
                 _log("digest_inline", session=session_id, chars=len(summary))
                 neutral = f"{summary} {neutral}"

--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -2187,6 +2187,41 @@ class Daemon:
         recent.append((sig, now))
         return is_dup
 
+    # A final shorter than this is already spoken-friendly — read it as-is
+    # on the floor. Longer means it's the agent's raw closing text (the
+    # "verbatim wall"); the no-LLM floor can't summarize it, so it swaps in
+    # a short canned line instead of reading the wall.
+    _FLOOR_FINAL_VERBATIM_MAX = 240
+
+    def _floor_text(self, kind: str, neutral: str, persona) -> str:
+        """No-LLM fallback for an event the harness punted on and no LLM
+        could summarize. The honest floor by event kind:
+
+        - ``final``  → short finals read as-is; long ones (the verbatim
+          wall) are replaced with a canned "go look" line. A final can't
+          be summarized without an LLM, so we never read the raw wall.
+        - ``intermediate`` → dropped. A mid-stream prose blip the brain
+          couldn't shape isn't worth a canned line; the next event narrates.
+        - everything else (tool-ish: repeat edits, long-running tags that
+          reached the harness) → the neutral TEMPLATE, which is already a
+          clean one-liner ("Editing auth.py"), never verbatim.
+        """
+        addr = getattr(persona, "address", "") or ""
+
+        def _with_addr(text: str) -> str:
+            t = text.rstrip(".")
+            if addr and not t.lower().endswith(addr.lower()):
+                return f"{t}, {addr}."
+            return f"{t}."
+
+        if kind == "final":
+            if neutral and len(neutral) <= self._FLOOR_FINAL_VERBATIM_MAX:
+                return _with_addr(neutral)
+            return _with_addr("That's done — the details are in your terminal")
+        if kind == "intermediate":
+            return ""
+        return neutral
+
     def _handle_event(self, req: dict) -> None:
         kind = req.get("kind") or ""
         neutral = (req.get("neutral") or "").strip()
@@ -2481,10 +2516,10 @@ class Daemon:
                 )
                 return
             _log("event_harness_punt", kind=kind, tag=tag)
-            # Track v2→v1 fallback. The harness (v2) returned None — either
-            # a clean punt (safety net) or it threw — so this event drops
-            # to the v1 path. reason distinguishes the two; the rate of
-            # this vs narration_spoken via=harness is the v2 health signal.
+            # Track v2→floor fallback. The harness (v2) returned None —
+            # either a clean punt (safety net) or it threw. reason
+            # distinguishes the two; the rate of this vs narration_spoken
+            # via=harness is the v2 health signal.
             try:
                 from heard import analytics
                 analytics.capture("harness_fallback", {
@@ -2495,7 +2530,32 @@ class Daemon:
                 })
             except Exception:
                 pass
-        # --- end harness path; fall through to v1 below ---
+            # --- v2 floor — graceful no-LLM fallback. NEVER read a final
+            # verbatim; a punted final gets a short canned line, a punted
+            # mid-stream blip is dropped, tool-ish events keep their clean
+            # template. This replaces the old v1 rewrite fallback, whose
+            # template→neutral chain read the raw wall when Haiku was down.
+            floor = self._floor_text(kind, neutral, persona)
+            if not floor:
+                _log("event_drop", kind=kind, tag=tag, reason="floor_drop")
+                return
+            info = self.router._sessions.get(session_id)  # noqa: SLF001
+            history_meta = {
+                "kind": kind, "tag": tag, "neutral": neutral,
+                "profile": cfg.get("verbosity", "normal"),
+                "repo_name": getattr(info, "repo_name", "") or "",
+                "cwd": cwd or "", "via": "floor",
+            }
+            _log("event_speak", kind=kind, tag=tag, persona=persona.name,
+                 chars=len(floor), via="floor")
+            self._start_speech(
+                floor, cfg=cfg, persona=persona, session_id=session_id,
+                history_meta=history_meta, priority=(kind == "intermediate"),
+            )
+            return
+        # --- end harness path. Below: v1 path, reached only when the
+        # harness is disabled (config). Slated for deletion once the
+        # brain is mandatory. ---
 
         if kind == "tool_pre":
             density = self.sessions.tool_density(session_id)

--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -56,32 +56,6 @@ DEBUG = os.environ.get("HEARD_DEBUG", "").lower() in ("1", "true", "yes")
 # per-event lines accumulate into hundreds of MB.
 _LOG_ROTATE_BYTES = 10 * 1024 * 1024
 
-# Safety cap for the v1 prose fallback. When the harness punts AND the
-# v1 persona rewrite ALSO fails (same Haiku blip), rewrite() returns the
-# raw neutral text — and on a long final that means reading a 1000+
-# char wall verbatim (the "it read everything" bug). Condensed output
-# (harness OR a working Haiku rewrite) never reaches this length, so
-# anything past the cap is a verbatim failure-fallback: truncate it.
-_FALLBACK_PROSE_CAP = 600
-_FALLBACK_PROSE_TARGET = 440
-
-
-def _cap_runaway_prose(text: str) -> str:
-    """Truncate a runaway verbatim prose fallback to a spoken-length
-    chunk, cutting at a sentence end (preferred) or word boundary, with
-    an audible trailing marker. No-op below the cap so normal condensed
-    narration is untouched."""
-    if len(text) <= _FALLBACK_PROSE_CAP:
-        return text
-    head = text[:_FALLBACK_PROSE_TARGET]
-    cut = max(head.rfind(". "), head.rfind("! "), head.rfind("? "))
-    if cut >= _FALLBACK_PROSE_TARGET - 220:
-        return head[:cut + 1] + " There's more — I'll spare you the rest."
-    sp = head.rfind(" ")
-    head = head[:sp] if sp > 0 else head
-    return head.rstrip(" ,;:—-") + "… I'll spare you the rest."
-
-
 def _log(event: str, **fields: object) -> None:
     """One structured line per event, parseable by eye and by grep.
 
@@ -2279,7 +2253,7 @@ class Daemon:
 
         cfg = config.load(cwd=cwd)
         persona = self._persona_for(cfg)
-        session = self.sessions.touch(session_id, cwd=cwd)
+        self.sessions.touch(session_id, cwd=cwd)  # marks the session active
         # Note this event so the router knows the session is active.
         # ``abs_path`` in ctx (set by templates for Edit / Write /
         # NotebookEdit) is the load-bearing signal for project
@@ -2553,169 +2527,6 @@ class Daemon:
                 history_meta=history_meta, priority=(kind == "intermediate"),
             )
             return
-        # --- end harness path. Below: v1 path, reached only when the
-        # harness is disabled (config). Slated for deletion once the
-        # brain is mandatory. ---
-
-        if kind == "tool_pre":
-            density = self.sessions.tool_density(session_id)
-            self.sessions.record_tool_event(session_id)
-            v_decision = verbosity.classify_pre(cfg, tag, density)
-            if v_decision == "drop":
-                _log("event_drop", kind=kind, tag=tag, reason="verbosity_pre", density=density)
-                return
-            if v_decision == "digest":
-                # Profile says digest (Brief always, Normal under
-                # burst). Stash for the next prose-arrival to drain.
-                self.router.add_to_digest(session_id, kind, tag, neutral, ctx)
-                _log("event_deferred", kind=kind, tag=tag, reason="verbosity_digest", density=density)
-                return
-        elif kind == "tool_post":
-            if tag in ("tool_post_failure", "tool_post_command_failed"):
-                self.sessions.note_failure(session_id)
-                session = self.sessions.get(session_id)
-            if verbosity.classify_post(cfg, tag) != "speak":
-                _log("event_drop", kind=kind, tag=tag, reason="verbosity_post")
-                return
-        elif kind in ("intermediate", "final"):
-            if verbosity.classify_prose(cfg) != "speak":
-                _log("event_drop", kind=kind, tag=tag, reason="profile_prose_silent")
-                return
-            # No `final_budget` truncation anymore — _SHARED_NARRATION_RULES
-            # tells Haiku to compress aggressively, so silently dropping
-            # the trailing half of a multi-topic answer just to fit a
-            # 600-char cap (the bug Christian hit, where my own multi-
-            # part replies got cut mid-thought) is the wrong tradeoff.
-            # The raw-persona path (no Haiku) is now also un-budgeted —
-            # if someone forks a raw persona and feeds it a wall of text,
-            # they get the wall.
-            # Drain pending tool digest for this session BEFORE the
-            # prose plays — gives the user a coherent "Made 3 edits,
-            # ran tests. OK, all green." narrative instead of stale
-            # tool announcements queueing up behind the prose.
-            # Only prefix the repo label when 2+ agents are active —
-            # in a solo session "Heard: 3 reads" is just noise; the
-            # listener knows which project they're in.
-            multi_active = len(self.router.list_active()) > 1
-            summary = self.router.drain_session_summary(
-                session_id, include_label=multi_active
-            )
-            if summary:
-                _log("digest_inline", session=session_id, chars=len(summary))
-                neutral = f"{summary} {neutral}"
-
-        if not neutral:
-            _log("event_drop", kind=kind, tag=tag, reason="empty_neutral")
-            return
-
-        # Multi-agent routing. In SOLO mode (single session) this is a
-        # no-op pass-through. In SWARM (2+ active) we drop routine
-        # events from non-focus sessions and prefix critical pierces
-        # with "Agent <name>:". In PINNED, only the pinned session
-        # gets unconditional play; others still pierce on critical.
-        decision = self.router.classify(
-            kind=kind,
-            tag=tag,
-            session_id=session_id,
-            agent_voices=cfg.get("agent_voices") or {},
-            auto_voices=bool(cfg.get("multi_agent_auto_voices", False)),
-        )
-        if decision.action == "drop":
-            _log("event_drop", kind=kind, tag=tag, session=session_id, reason="multi_agent_drop")
-            return
-        if decision.action == "defer_to_digest":
-            self.router.add_to_digest(session_id, kind, tag, neutral, ctx)
-            _log("event_deferred", kind=kind, tag=tag, session=session_id)
-            return
-
-        final = persona.rewrite(
-            event_kind=kind,
-            neutral=neutral,
-            tag=tag,
-            ctx=ctx,
-            session=session,
-        )
-        if not final:
-            _log("event_drop", kind=kind, tag=tag, reason="persona_empty", persona=persona.name)
-            return
-
-        # Safety cap: if the rewrite fell back to raw neutral (Haiku blip
-        # / raw persona) on a long final, don't read the wall verbatim.
-        if kind in ("intermediate", "final"):
-            capped = _cap_runaway_prose(final)
-            if capped != final:
-                _log("v1_prose_capped", kind=kind, was=len(final), now=len(capped))
-                final = capped
-
-        # `final_budget` truncation removed: the tightened Haiku prompt
-        # (PR #17 — "summarise the source, never read it verbatim")
-        # caps spoken length at the prompt layer instead, and chopping
-        # multi-topic answers at a sentence boundary dropped the second
-        # half entirely with no audible "…and more". Long finals stay
-        # long; if Haiku misbehaves and produces a wall, the user hears
-        # the wall — better than silent truncation.
-
-        # Apply the router's label prefix (e.g. "Agent api: ") AFTER
-        # persona rewrite + truncation so it survives both. Empty in
-        # solo / focus paths.
-        if decision.label_prefix:
-            final = decision.label_prefix + final
-
-        # Voice override (per-agent voice mapping) wins over both
-        # cfg["voice"] and persona.voice — the user explicitly mapped
-        # this repo to that voice in agent_voices.
-        if decision.voice_override:
-            cfg = dict(cfg)
-            cfg["voice"] = decision.voice_override
-
-        self.sessions.note_topic(session_id, tag)
-
-        _log("event_speak", kind=kind, tag=tag, persona=persona.name, chars=len(final))
-        # Tier 2 sampled — only fires if `product_analytics: true` AND the
-        # 1:10 dice roll hits. char_count bucketed for cardinality safety.
-        try:
-            from heard import analytics
-            if analytics.sampled():
-                if len(final) < 100:
-                    char_bucket = "0-99"
-                elif len(final) < 200:
-                    char_bucket = "100-199"
-                elif len(final) < 400:
-                    char_bucket = "200-399"
-                else:
-                    char_bucket = "400+"
-                analytics.capture("narration_spoken", {
-                    "kind": kind,
-                    "tag": tag,
-                    "persona": persona.name,
-                    "backend": type(self.tts).__name__,
-                    "char_count_bucket": char_bucket,
-                    "via": "v1",
-                })
-        except Exception:
-            pass
-        if DEBUG:
-            _log("event_speak_detail", text=final)
-        # Bundle the context the spoken-history log needs after the
-        # utterance plays. Captured here while we still have the
-        # neutral text + tag + cwd; the queue carries it through.
-        info = self.router._sessions.get(session_id)  # noqa: SLF001
-        history_meta = {
-            "kind": kind,
-            "tag": tag,
-            "neutral": neutral,
-            "profile": cfg.get("verbosity", "normal"),
-            "repo_name": getattr(info, "repo_name", "") or "",
-            "cwd": cwd or "",
-        }
-        self._start_speech(
-            final,
-            cfg=cfg,
-            persona=persona,
-            session_id=session_id,
-            voice_override=decision.voice_override,
-            history_meta=history_meta,
-        )
 
     def _persona_for(self, cfg: dict) -> persona_mod.Persona:
         name = cfg.get("persona", "raw")

--- a/heard/daemon.py
+++ b/heard/daemon.py
@@ -2384,15 +2384,12 @@ class Daemon:
                 )
                 return
 
-        # --- Layer 5 — Harness NARRATE prototype (Phase 3 step 6). ---
-        # Driven by cfg["harness_enabled"]; off by default → zero impact
-        # on the v1 path. When on, the harness gets first shot at every
-        # incoming event. Three outcomes:
-        #   - None              → fall through to v1 (safety net)
+        # --- Layer 5 — Harness (the mandatory narration brain). ---
+        # The harness gets first shot at every prose/final event (tools
+        # fast-pathed above). Three outcomes:
+        #   - None              → no-LLM floor below (v1 sunset, 2026-06)
         #   - speak=False       → harness chose silence; suppress
         #   - speak=True        → enqueue harness.text directly
-        # This is the make-or-break A/B for the v2 architecture; see
-        # plan file Phase 3 step 6 for the kill criteria.
         if harness.is_enabled(cfg):
             harness_error = False
             try:

--- a/heard/harness.py
+++ b/heard/harness.py
@@ -98,9 +98,16 @@ class HarnessDecision:
 
 
 def is_enabled(cfg: dict[str, Any]) -> bool:
-    """True when the harness path is active for this user. Default
-    False — flipping the flag in config opts in."""
-    return bool(cfg.get("harness_enabled", False))
+    """The brain is mandatory — always on. Prose/finals route through the
+    harness; when it punts (LLM unreachable), the daemon's no-LLM floor
+    catches it (clean template for tools, a canned line for finals). The
+    old `harness_enabled` flag is now inert: there is no v1 path to fall
+    back to, so disabling the brain would just mean the floor for
+    everything. Kept as a function (not deleted) so every call site —
+    warm_cache, narrate, the daemon gate — stays a one-liner.
+
+    The `cfg` arg is retained for signature stability (callers pass it)."""
+    return True
 
 
 def warm_cache(

--- a/heard/multi_agent.py
+++ b/heard/multi_agent.py
@@ -324,9 +324,17 @@ _TAG_TO_VERB = {
 }
 
 
-def _format_session_summary(info: SessionInfo, events: list[dict[str, Any]]) -> str | None:
+def _format_session_summary(
+    info: SessionInfo, events: list[dict[str, Any]], include_label: bool = True
+) -> str | None:
     """Per-session line for the digest. "Api: 5 edits, ran the tests."
-    Returns None if no events count toward the summary."""
+    Returns None if no events count toward the summary.
+
+    ``include_label`` prefixes the repo label ("Api: …") — needed in
+    swarm to disambiguate which agent the summary is about, but pure
+    noise in a solo session where there's only one agent. Solo callers
+    pass False so the listener hears "3 reads, a search." not
+    "Heard: 3 reads, a search." every burst."""
     by_verb: dict[str, int] = {}
     for e in events:
         verb = _TAG_TO_VERB.get(e.get("tag", ""), "operation")
@@ -339,12 +347,16 @@ def _format_session_summary(info: SessionInfo, events: list[dict[str, Any]]) -> 
             parts.append(f"a {verb}")
         else:
             parts.append(f"{count} {verb}s")
+    body = ", ".join(parts)
+    if not include_label:
+        return f"{body[:1].upper()}{body[1:]}."
     label = _label_for(info).capitalize()
-    return f"{label}: {', '.join(parts)}."
+    return f"{label}: {body}."
 
 
 def format_project_summary(
-    label: str, events: list[dict[str, Any]], member_count: int = 1
+    label: str, events: list[dict[str, Any]], member_count: int = 1,
+    include_label: bool = True,
 ) -> str | None:
     """Aggregated tag-count summary for a project's drain — pools events
     from every session in the project so multiple agents working in
@@ -372,7 +384,10 @@ def format_project_summary(
     tail = ""
     if member_count >= 2:
         tail = f" across {_count_word(member_count)} agents"
-    return f"{label.capitalize()}: {', '.join(parts)}{tail}."
+    body = ", ".join(parts)
+    if not include_label:
+        return f"{body[:1].upper()}{body[1:]}{tail}."
+    return f"{label.capitalize()}: {body}{tail}."
 
 
 def _count_word(n: int) -> str:
@@ -801,13 +816,18 @@ class MultiAgentRouter:
                     info.pending_digest.clear()
             return out
 
-    def drain_session_summary(self, session_id: str) -> str | None:
+    def drain_session_summary(
+        self, session_id: str, include_label: bool = True
+    ) -> str | None:
         """Drain ONE session's pending digest and format it as a
         spoken summary. Used by the daemon when intermediate prose
         arrives — we play the tool summary first ("3 edits, ran the
         tests"), then the prose ("OK, all green"), so the user gets
         a coherent narrative instead of a wall of "editing X.py.
-        editing Y.py..." preceding the prose."""
+        editing Y.py..." preceding the prose.
+
+        ``include_label`` is forwarded to ``_format_session_summary`` —
+        solo callers pass False to drop the redundant repo prefix."""
         with self._lock:
             info = self._sessions.get(session_id)
             if info is None or not info.pending_digest:
@@ -816,7 +836,7 @@ class MultiAgentRouter:
             info.pending_digest.clear()
         # _format_session_summary is module-level, takes both args.
         # Call it OUTSIDE the lock — pure function, no shared state.
-        return _format_session_summary(info, events)
+        return _format_session_summary(info, events, include_label=include_label)
 
     # --- resume-from-pause helpers ---------------------------------------
     #

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -962,6 +962,28 @@ Rules for this summary:
   no leading "I", no scare quotes.
 """
 
+# Solo variant — one agent, one project, the developer knows exactly
+# which repo they're in. Naming the project every burst is the
+# "constantly saying the name of the repo" complaint, so this drops the
+# label entirely and just narrates the work.
+_PROJECT_SUMMARY_RULES_SOLO = """\
+You're summarising a burst of work one AI coding agent just did, for a
+developer who has stepped away from the keyboard. The output will be
+spoken aloud in the persona's voice as one short status update.
+
+Rules for this summary:
+- Do NOT name the project or repo — there's only one and the developer
+  knows where they are. Just narrate the work.
+- One short sentence, spoken length. ("Read through the auth flow and
+  ran the tests — all green.")
+- Aggregate similar events ("a few edits to the parser", not a list).
+- Name 1-3 files only when it sharpens the picture; otherwise omit.
+- Pass through verbatim test / build / search outcomes if present
+  ("tests passed", "build failed", "no matches").
+- Past tense — the work has happened. No markdown, no bullet lists,
+  no leading "I", no scare quotes.
+"""
+
 
 def _format_events_for_summary(
     label: str, events: list[dict[str, Any]], member_count: int
@@ -969,8 +991,10 @@ def _format_events_for_summary(
     """Bullet-list shape Haiku can scan; prefer the event's neutral
     narration when present (already-natural prose from templates.py),
     fall back to the raw tag so an event with no text still counts."""
-    lines = [
-        f"Project: {label}",
+    lines = []
+    if label:
+        lines.append(f"Project: {label}")
+    lines += [
         f"Agents involved: {member_count}",
         f"Event count: {len(events)}",
         "Events in order:",
@@ -991,6 +1015,7 @@ def summarize_project(
     events: list[dict[str, Any]],
     member_count: int = 1,
     *,
+    solo: bool = False,
     max_tokens: int = HAIKU_MAX_TOKENS * 2,
     timeout: float = HAIKU_TIMEOUT_S,
 ) -> str | None:
@@ -999,16 +1024,20 @@ def summarize_project(
     managed Heard cloud → ``claude -p``), with a digest-shaped prompt
     designed for "one project's chunk of work, rolled up." Returns
     ``None`` when no LLM path is available so the daemon can fall back
-    to the tag-count formatter."""
+    to the tag-count formatter.
+
+    ``solo`` selects the no-project-name rules — used when there's a
+    single agent on a single project, so the summary narrates the work
+    without prefixing the repo label every time."""
     if not events or not _haiku_enabled():
         return None
-    user_msg = _format_events_for_summary(label, events, member_count)
+    user_msg = _format_events_for_summary("" if solo else label, events, member_count)
     full_system = (
         _SHARED_NARRATION_RULES
         + "\n\n"
         + persona.system_prompt
         + "\n\n"
-        + _PROJECT_SUMMARY_RULES
+        + (_PROJECT_SUMMARY_RULES_SOLO if solo else _PROJECT_SUMMARY_RULES)
     )
 
     from heard import providers as _providers

--- a/heard/templates.py
+++ b/heard/templates.py
@@ -159,6 +159,54 @@ def _first_token(command: str) -> str:
     return parts[i] if i < len(parts) else ""
 
 
+# First words that are NOT imperative verbs — leave these descriptions
+# alone rather than mangle them ("Quick check…" must not become
+# "Quicking…"). Small, high-frequency stoplist; anything else is treated
+# as a leading verb.
+_NOT_A_LEADING_VERB = frozenset({
+    "a", "an", "the", "quick", "sanity", "full", "final", "one", "two",
+    "all", "both", "no", "first", "second", "double", "re",
+})
+
+
+def _to_gerund(word: str) -> str:
+    """Best-effort present participle of a single imperative verb,
+    preserving the original capitalisation. English gerund morphology is
+    irregular; this covers the common cases (silent-e drop, CVC doubling)
+    and falls back to bare +ing otherwise."""
+    low = word.lower()
+    if low.endswith("ing"):
+        return word
+    if low.endswith("ie"):  # die → dying, tie → tying
+        return word[:-2] + "ying"
+    if low.endswith("e") and not low.endswith(("ee", "oe", "ye")):
+        return word[:-1] + "ing"  # locate → locating, probe → probing
+    # Short CVC verbs double the final consonant: run → running, set →
+    # setting. Restricted to short words so multi-syllable verbs (open,
+    # visit) don't wrongly double.
+    if 2 <= len(low) <= 4:
+        c1, c2 = low[-1], low[-2]
+        if c1 not in "aeiouwxy" and c2 in "aeiou" and (len(low) < 3 or low[-3] not in "aeiou"):
+            return word + c1 + "ing"
+    return word + "ing"  # extract → extracting, verify → verifying
+
+
+def _present_continuous(text: str) -> str:
+    """Turn an imperative intent line ("Locate the sample video") into
+    present continuous ("Locating the sample video"). Only the leading
+    verb is transformed; the rest is untouched. Non-verb openers (per
+    `_NOT_A_LEADING_VERB`) and non-alphabetic first tokens are left as-is."""
+    if not text:
+        return text
+    parts = text.split(" ", 1)
+    first = parts[0]
+    core = first.replace("-", "")
+    if not core.isalpha() or first.lower() in _NOT_A_LEADING_VERB:
+        return text
+    gerund = _to_gerund(first)
+    return gerund + (" " + parts[1] if len(parts) > 1 else "")
+
+
 def _bash_tag_and_text(command: str | None, description: str | None) -> tuple[str, str]:
     cmd = (command or "").strip()
     low = cmd.lower()
@@ -180,9 +228,12 @@ def _bash_tag_and_text(command: str | None, description: str | None) -> tuple[st
 
     # Description (when CC populates it) wins over verb detection —
     # the agent's hand-written intent line is almost always more
-    # specific than what we'd derive from the command verb alone.
+    # specific than what we'd derive from the command verb alone. CC
+    # writes these in the imperative ("Locate sample video", "Probe
+    # specs"); narration wants present continuous ("Locating sample
+    # video", "Probing specs") since the work is in flight.
     if description:
-        return "tool_bash_generic", description.rstrip(".") + "."
+        return "tool_bash_generic", _present_continuous(description.rstrip(".")) + "."
 
     # No description: extract intent from the command's first verb so
     # the user hears "Searching the codebase." instead of the dreaded

--- a/packaging/setup.py
+++ b/packaging/setup.py
@@ -24,7 +24,7 @@ sys.path.insert(0, ROOT)
 from setuptools import setup  # noqa: E402
 
 APP_NAME = "Heard"
-APP_VERSION = "1.0.20"
+APP_VERSION = "1.0.21"
 APP_BUNDLE_ID = "dev.heard.menubar"
 
 APP = [os.path.join(HERE, "app_entry.py")]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "heard"
-version = "1.0.20"
+version = "1.0.21"
 description = "A voice companion for your AI coding agents. Heard speaks your agent's replies so you can keep working."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/test_final_floor.py
+++ b/tests/test_final_floor.py
@@ -1,0 +1,65 @@
+"""The v2 floor — graceful no-LLM fallback when the harness punts.
+
+A punted FINAL must never be read verbatim (the "it read everything"
+bug). The floor reads short finals as-is, swaps long ones for a canned
+line, drops mid-stream prose, and keeps tool templates clean.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _quiet_hotkey(monkeypatch):
+    monkeypatch.setattr("heard.hotkey.start", lambda *a, **kw: None)
+    monkeypatch.setattr("heard.accessibility.ensure_trusted", lambda **kw: True)
+    yield
+
+
+@pytest.fixture
+def daemon(tmp_path, monkeypatch):
+    monkeypatch.setattr("heard.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("heard.config.MODELS_DIR", tmp_path / "models")
+    monkeypatch.setattr("heard.config.SOCKET_PATH", tmp_path / "daemon.sock")
+    monkeypatch.setattr("heard.config.LOG_PATH", tmp_path / "daemon.log")
+    monkeypatch.setattr("heard.config.PID_PATH", tmp_path / "daemon.pid")
+    from heard.daemon import Daemon
+
+    return Daemon()
+
+
+_NO_ADDR = types.SimpleNamespace(address="")
+_SIR = types.SimpleNamespace(address="sir")
+
+
+def test_long_final_never_read_verbatim(daemon):
+    wall = "So I went through the auth flow and " + ("blah " * 80)
+    out = daemon._floor_text("final", wall, _NO_ADDR)
+    assert "blah" not in out  # the wall is gone
+    assert out == "That's done — the details are in your terminal."
+
+
+def test_short_final_read_as_is(daemon):
+    out = daemon._floor_text("final", "All tests pass.", _NO_ADDR)
+    assert out == "All tests pass."
+
+
+def test_address_suffix_applied(daemon):
+    out = daemon._floor_text("final", "All tests pass.", _SIR)
+    assert out == "All tests pass, sir."
+    # Canned line also gets the address.
+    wall = "x" * 500
+    assert daemon._floor_text("final", wall, _SIR).endswith(", sir.")
+
+
+def test_intermediate_prose_is_dropped(daemon):
+    assert daemon._floor_text("intermediate", "Thinking about the parser...", _NO_ADDR) == ""
+
+
+def test_tool_keeps_clean_template(daemon):
+    # A tool event that reached the harness (repeat edit) and punted keeps
+    # its clean template line — never verbatim, no canned final line.
+    assert daemon._floor_text("tool_pre", "Editing auth.py.", _NO_ADDR) == "Editing auth.py."

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -47,15 +47,21 @@ def _ev(
 # --- gating --------------------------------------------------------------
 
 
-def test_is_enabled_defaults_false():
-    assert harness.is_enabled({}) is False
-    assert harness.is_enabled({"harness_enabled": False}) is False
+def test_is_enabled_always_true():
+    # The brain is mandatory now — the harness_enabled flag is inert.
+    # Prose/finals always route through the harness; the daemon's no-LLM
+    # floor catches a punt. There is no v1 path to disable into.
+    assert harness.is_enabled({}) is True
+    assert harness.is_enabled({"harness_enabled": False}) is True
     assert harness.is_enabled({"harness_enabled": True}) is True
 
 
-def test_narrate_returns_none_when_disabled():
+def test_narrate_returns_none_when_llm_unreachable():
+    # narrate punts (returns None → daemon floor) when no LLM provider is
+    # reachable — not because of a disable flag (there isn't one anymore).
     reg = AgentStateRegistry()
-    out = harness.narrate(_ev(), cfg={}, persona=_persona(), agent_states=reg)
+    with patch.object(harness.persona_mod, "call_with_prompt", side_effect=Exception("no provider")):
+        out = harness.narrate(_ev(), cfg={}, persona=_persona(), agent_states=reg)
     assert out is None
 
 
@@ -618,16 +624,6 @@ def test_narrate_reads_mode_from_cfg():
         harness.narrate(event, cfg=cfg, persona=_persona(), agent_states=reg)
 
     assert "COMPANION MODE" in captured["system"]
-
-
-def test_warm_cache_noop_when_disabled():
-    """If harness_enabled is False, warm_cache must NOT make an LLM
-    call. Users on v1 path pay nothing for warming."""
-    from unittest.mock import patch
-    cfg = {"harness_enabled": False, "mode": "copilot"}
-    with patch.object(harness.persona_mod, "call_with_prompt") as m:
-        harness.warm_cache(cfg=cfg, persona=_persona())
-    assert m.call_count == 0
 
 
 def test_warm_cache_calls_llm_when_enabled():

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -124,6 +124,23 @@ def test_format_project_summary_marks_multi_agent_aggregation():
     assert "across two agents" in pooled
 
 
+def test_project_summary_drops_repo_label_in_solo():
+    """Solo (include_label=False) summaries narrate the work WITHOUT the
+    repo-name prefix — "constantly saying the name of the repo" was the
+    dogfooding complaint. Multi-agent keeps the label to disambiguate."""
+    events = [
+        {"tag": "tool_bash_read", "ts": 1.0},
+        {"tag": "tool_bash_read", "ts": 2.0},
+        {"tag": "tool_bash_grep_cmd", "ts": 3.0},
+    ]
+    labeled = multi_agent.format_project_summary("api", events, include_label=True)
+    assert labeled.startswith("Api:")
+    solo = multi_agent.format_project_summary("api", events, include_label=False)
+    assert "api" not in solo.lower()
+    assert ":" not in solo  # no "Label:" prefix
+    assert solo.endswith(".")
+
+
 def test_project_flush_idle_drain_aggregates_same_project():
     """Two CC sessions in the same project (same cwd basename) drain
     as one combined summary stream — that's the "project-level

--- a/tests/test_project_tag.py
+++ b/tests/test_project_tag.py
@@ -39,6 +39,11 @@ def _make_daemon(tmp_path, monkeypatch, cfg_overrides=None):
     from heard.daemon import Daemon
     d = Daemon()
     d.cfg = _load()
+    # The project tag only fires with 2+ active agents (solo has no
+    # ambiguity to resolve). Default the test daemon to a multi-agent
+    # fleet so the switching tests exercise the tag; the solo test
+    # overrides this back to a single agent.
+    d.router.list_active = lambda: ["a", "b"]
     return d
 
 
@@ -56,6 +61,20 @@ def test_first_mention_and_switch_get_tagged(tmp_path, monkeypatch):
     # Back to heard → tagged again (it changed).
     assert d._with_project_tag("Committing.", {"repo_name": "heard"}) == \
         "Now on heard. Committing."
+
+
+def test_solo_never_tags_the_project(tmp_path, monkeypatch):
+    """Single active agent → no "Now on <project>" ever; there's only one
+    project, so naming it every time is the repo-name-noise complaint.
+    The tracker still updates so a later switch into multi-agent tags."""
+    d = _make_daemon(tmp_path, monkeypatch)
+    d.router.list_active = lambda: ["only"]  # solo
+    assert d._with_project_tag("Running tests.", {"repo_name": "heard"}) == \
+        "Running tests."
+    assert d._last_spoken_project == "heard"  # tracker still advanced
+    # Even switching projects stays untagged while solo.
+    assert d._with_project_tag("Deploying.", {"repo_name": "cadence"}) == \
+        "Deploying."
 
 
 def test_no_project_does_not_tag_or_reset(tmp_path, monkeypatch):

--- a/tests/test_speech_queue.py
+++ b/tests/test_speech_queue.py
@@ -155,21 +155,6 @@ def test_queue_caps_at_max_drops_oldest(tmp_path, monkeypatch):
     assert len(spoken) == 1 + cap, f"expected {1 + cap} played, got {len(spoken)}: {spoken}"
 
 
-def test_cap_runaway_prose_truncates_walls_keeps_short():
-    """The v1 fallback safety cap: a long verbatim wall (harness punted +
-    rewrite fell back to raw) gets truncated with an audible marker;
-    normal condensed narration is untouched."""
-    from heard.daemon import _FALLBACK_PROSE_CAP, _cap_runaway_prose
-    short = "Done. Tests pass, deployed to staging."
-    assert _cap_runaway_prose(short) == short
-    wall = "First sentence here. " * 80  # ~1680 chars
-    out = _cap_runaway_prose(wall)
-    assert len(out) < _FALLBACK_PROSE_CAP
-    assert "spare you the rest" in out
-    # cuts at a sentence boundary, not mid-word
-    assert not out.replace("There's more — I'll spare you the rest.", "").strip().endswith("Firs")
-
-
 def test_trial_ended_blurb_matches_actual_fallback(tmp_path, monkeypatch):
     """The trial-ended message must reflect what voice ACTUALLY remains —
     never claim 'switched to local voices' when it really went silent

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -13,8 +13,10 @@ def test_bash_git_commit_summary():
 
 
 def test_bash_generic_uses_description():
+    # Description is used (over verb detection) and spoken in present
+    # continuous: "Do the thing" → "Doing the thing".
     line = templates.pre_tool_line("Bash", {"command": "./scripts/do-thing", "description": "Do the thing"})
-    assert line == "Do the thing."
+    assert line == "Doing the thing."
 
 
 def test_edit_uses_basename_without_extension():
@@ -207,3 +209,20 @@ def test_compound_command_pipe():
 def test_compound_command_semicolon():
     line = templates.pre_tool_line("Bash", {"command": "cd build; make clean"})
     assert line == "Building."
+
+
+def test_bash_description_present_continuous():
+    """CC writes Bash descriptions in the imperative ("Locate sample
+    video"); narration speaks them in present continuous since the work
+    is in flight ("Locating sample video")."""
+    line = templates.pre_tool_line(
+        "Bash", {"command": "find ~ -name x", "description": "Locate sample video on Desktop"}
+    )
+    assert line == "Locating sample video on Desktop."
+    # silent-e drop, CVC doubling, hyphenated compound
+    assert templates._present_continuous("Probe specs") == "Probing specs"
+    assert templates._present_continuous("Set the env var") == "Setting the env var"
+    assert templates._present_continuous("Cost-estimate the push") == "Cost-estimating the push"
+    # already a gerund → unchanged; non-verb opener → left alone
+    assert templates._present_continuous("Running tests") == "Running tests"
+    assert templates._present_continuous("Quick check of logs") == "Quick check of logs"

--- a/tests/test_tool_dedup.py
+++ b/tests/test_tool_dedup.py
@@ -1,0 +1,72 @@
+"""Consecutive-duplicate tool-line suppression.
+
+A burst of reads / searches renders the same template line repeatedly
+("Reading a file." × 6, "Searching the codebase." × 4). Narrating each
+one is the robotic-repetition complaint. `Daemon._is_duplicate_tool_line`
+speaks the first and drops identical echoes within a short window, while
+leaving distinct lines and other sessions untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _quiet_hotkey(monkeypatch):
+    monkeypatch.setattr("heard.hotkey.start", lambda *a, **kw: None)
+    monkeypatch.setattr("heard.accessibility.ensure_trusted", lambda **kw: True)
+    yield
+
+
+@pytest.fixture
+def daemon(tmp_path, monkeypatch):
+    monkeypatch.setattr("heard.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("heard.config.MODELS_DIR", tmp_path / "models")
+    monkeypatch.setattr("heard.config.SOCKET_PATH", tmp_path / "daemon.sock")
+    monkeypatch.setattr("heard.config.LOG_PATH", tmp_path / "daemon.log")
+    monkeypatch.setattr("heard.config.PID_PATH", tmp_path / "daemon.pid")
+    from heard.daemon import Daemon
+
+    return Daemon()
+
+
+def test_burst_collapses_to_distinct_lines(daemon):
+    seq = [
+        "Reading a file.",
+        "Reading a file.",
+        "Searching the codebase.",
+        "Reading a file.",
+        "Searching the codebase.",
+        "Running the tests.",
+    ]
+    spoke = [s for s in seq if not daemon._is_duplicate_tool_line("sess", s)]
+    assert spoke == [
+        "Reading a file.",
+        "Searching the codebase.",
+        "Running the tests.",
+    ]
+
+
+def test_other_session_not_affected(daemon):
+    assert daemon._is_duplicate_tool_line("a", "Reading a file.") is False
+    # Same line, different session → still speaks.
+    assert daemon._is_duplicate_tool_line("b", "Reading a file.") is False
+    # Same session repeat → suppressed.
+    assert daemon._is_duplicate_tool_line("a", "Reading a file.") is True
+
+
+def test_case_and_space_insensitive(daemon):
+    assert daemon._is_duplicate_tool_line("s", "Searching the codebase.") is False
+    assert daemon._is_duplicate_tool_line("s", "searching   the  codebase.") is True
+
+
+def test_window_expiry_lets_line_speak_again(daemon, monkeypatch):
+    import heard.daemon as dmod
+
+    t = [1000.0]
+    monkeypatch.setattr(dmod.time, "monotonic", lambda: t[0])
+    assert daemon._is_duplicate_tool_line("s", "Reading a file.") is False
+    t[0] += daemon._TOOL_DUP_WINDOW_S + 1.0
+    # Window elapsed → no longer a duplicate.
+    assert daemon._is_duplicate_tool_line("s", "Reading a file.") is False


### PR DESCRIPTION
## Summary

Sunsets the v1 narration path. The harness **brain is now mandatory** for prose/finals; the old `verbosity → multi_agent → persona.rewrite` fallback chain is deleted; a new **no-LLM floor** catches harness punts so a long final is never read verbatim again. Plus a round of solo-narration cleanup and present-continuous tool narration.

Motivation: dogfooding + PostHog showed real users (incl. a tester at ~85% v1) hearing verbose, repetitive, repo-prefixed, sometimes-verbatim narration. Root cause was a mix of (a) old configs silently stranded on v1 because `harness_enabled` defaulted False in code, and (b) v1's verbatim-wall fallback on Haiku blips.

## What changed (commit by commit)

- **Solo-noise cleanup** — suppress consecutive duplicate tool lines (`_is_duplicate_tool_line`); drop the repo-label prefix from digest summaries in solo; never say "Now on \<project\>" with a single agent; `summarize_project` gains a solo mode that doesn't name the repo.
- **v2 floor** (`Daemon._floor_text`) — when the brain punts (LLM unreachable: managed cap, outage, no provider), a final gets a short canned line ("That's done — the details are in your terminal") instead of its raw text read verbatim; mid-stream prose is dropped; tools keep their clean template.
- **Brain mandatory + delete v1** — `harness.is_enabled()` always True (the flag was default-False in code, stranding old configs); deleted the ~164-line v1 branch in `_handle_event` and `_cap_runaway_prose`. `persona.rewrite()` + Haiku-rewrite helpers are now orphaned corpse code (kept; flagged "don't call/extend"; a future cleanup deletes them).
- **Docs** — CLAUDE.md gets a "v1 sunset (2026-06)" section + corrected harness/daemon/persona rows.
- **Present-continuous tool narration** — CC writes Bash descriptions imperatively ("Locate sample video"); `_present_continuous` gerund-izes the leading verb ("Locating sample video"). Handles silent-e drop, CVC doubling, hyphenated compounds; leaves non-verb openers and existing gerunds alone.

## Note for @JustinWei

Rebased cleanly onto your `#19` dead-code sweep — no conflicts (our removals hit different functions). One overlap to be aware of: I leave `persona.rewrite` + its `_*_haiku_rewrite` helpers as **intentional orphans** rather than removing them in this PR (removing them means reworking ~10 persona tests). They're flagged in CLAUDE.md as corpse code; a follow-up sweep like yours can take them.

## Verification

755 tests pass, ruff clean. Hot-patched + dogfooded live: brain handled 38/38 prose/finals with 0 punts; tool bursts no longer repeat; bash descriptions speak present-continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)