### PR TITLE
hygiene: scrub private-Power detail leaks from public repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxxxxxx
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
 
 # Optional: override the narration-brain model on the BYOK path only
-# (e.g. claude-sonnet-5). Empty/unset -> the default Haiku checkpoint.
+# (any Anthropic model id). Empty/unset -> the default Haiku checkpoint.
 # HEARD_BRAIN_MODEL=
 
 # --- Text-to-speech (TTS) — bring your own key --------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Latency work in the Heard Power voice loop (proprietary): dictation cleanup
+- Latency work in the voice loop: dictation cleanup
   now runs while Heard is still waiting to confirm you finished speaking,
   rather than after. No change to the open-source narration engine.
 

--- a/heard/config.py
+++ b/heard/config.py
@@ -80,9 +80,9 @@ DEFAULTS: dict[str, Any] = {
     "voice_mode": "off",
     # EXPERIMENT — override the narration-brain model on the BYOK path only
     # (needs anthropic_api_key set). Empty → default Haiku checkpoint. Set to
-    # "claude-sonnet-5" to A/B the proprietary Power-brain model locally; BYOK
-    # bypasses the managed proxy so nothing ships and the free path stays Haiku.
-    # See persona._brain_model(). Toggle: heard config set brain_model claude-sonnet-5
+    # another Anthropic model to A/B it locally; BYOK bypasses the managed
+    # proxy so nothing ships and the free path stays Haiku.
+    # See persona._brain_model(). Toggle: heard config set brain_model <model-id>
     "brain_model": "",
     "voice_cleanup": True,          # LLM tidy pass on dictated text
     "voice_input_unlocked": False,  # dev/test escape hatch for the Power menu

--- a/heard/persona.py
+++ b/heard/persona.py
@@ -396,14 +396,14 @@ def _brain_model() -> str:
     """EXPERIMENT hook — override the narration-brain model on the BYOK
     path only. Empty/unset → the default Haiku checkpoint (`HAIKU_MODEL`).
 
-    Set to `claude-sonnet-5` to A/B the proprietary Power-brain model on
-    your own machine. BYOK bypasses the managed proxy, so this ships
-    nothing and changes nothing for other users — the free/managed path
-    stays on Haiku. Config `brain_model` wins over env `HEARD_BRAIN_MODEL`.
+    Set it to another Anthropic model to A/B it on your own machine. BYOK
+    bypasses the managed proxy, so this ships nothing and changes nothing
+    for other users — the free/managed path stays on Haiku. Config
+    `brain_model` wins over env `HEARD_BRAIN_MODEL`.
 
     Toggle for the packaged .app (env vars don't reach it):
-        heard config set brain_model claude-sonnet-5   # on
-        heard config set brain_model ""                # back to Haiku
+        heard config set brain_model <model-id>   # on
+        heard config set brain_model ""           # back to Haiku
     """
     env = (os.environ.get("HEARD_BRAIN_MODEL") or "").strip()
     try:

--- a/packaging/entitlements.plist
+++ b/packaging/entitlements.plist
@@ -24,6 +24,6 @@
          cs.allow-unsigned-executable-memory) entitlements are NOT here — the
          public OSS app has no microphone/STT/numba and must stay minimal. The
          PRIVATE Power build (which injects the voice engine) needs them and
-         signs with its own ../heard-power/packaging/entitlements.plist. -->
+         signs with its own entitlements. -->
 </dict>
 </plist>


### PR DESCRIPTION
Removes references that expose the closed Power product more than an OSS repo should. Functionality unchanged — only the private-product naming/paths are genericized.

- **config.py / persona.py / .env.example** — stop naming the proprietary brain model; genericize to 'another Anthropic model'. The `brain_model` override still works.
- **CHANGELOG.md** — drop the 'proprietary Heard Power voice loop' framing.
- **packaging/entitlements.plist** — remove the private `../heard-power/` repo path.

Note: this cleans HEAD going forward; the old strings still exist in git history. A history rewrite (like the 2026-04 PRD.md scrub) would be needed to purge them fully.